### PR TITLE
Replace all unsafe nodes["Principled BSDF"] direct accesses with nodes.get

### DIFF
--- a/hb_details.py
+++ b/hb_details.py
@@ -124,12 +124,14 @@ class GeoNodeLine(hb_types.GeoNodeObject):
         # Create black material
         mat = bpy.data.materials.new(f"{name}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
         curve.materials.append(mat)
-        
+
         # Set bevel for line thickness
         curve.bevel_depth = 0.002  # Small line thickness
-        
+
         return self.obj
     
     def set_points(self, start: Vector, end: Vector):
@@ -178,7 +180,9 @@ class GeoNodePolyline(hb_types.GeoNodeObject):
         # Create material
         mat = bpy.data.materials.new(f"{name}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = line_color
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = line_color
         curve.materials.append(mat)
         
         curve.bevel_depth = line_thickness
@@ -254,7 +258,9 @@ class GeoNodeCircle(hb_types.GeoNodeObject):
         # Set up material (black line) - match GeoNodeLine approach
         mat = bpy.data.materials.new(f"{name}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
         curve_data.materials.append(mat)
         
         # Set bevel for line thickness
@@ -310,7 +316,9 @@ class GeoNodeText(hb_types.GeoNodeObject):
         # Create black material
         mat = bpy.data.materials.new(f"{name}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
         text_data.materials.append(mat)
         
         # Set extrude for visibility (thin 3D text)

--- a/hb_layouts.py
+++ b/hb_layouts.py
@@ -167,9 +167,11 @@ class TitleBlock:
         # Black material
         mat = bpy.data.materials.new(f"{scene.name}_{field_name}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
         text_obj.data.materials.append(mat)
-        
+
         self.text_objects.append(text_obj)
         return text_obj
     
@@ -1434,9 +1436,11 @@ class MultiView(LayoutView):
         # Black material
         mat = bpy.data.materials.new(f"Label_{text}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
         text_obj.data.materials.append(mat)
-        
+
         return text_obj
 
 

--- a/operators/details.py
+++ b/operators/details.py
@@ -2567,7 +2567,9 @@ class home_builder_details_OT_offset_curve(bpy.types.Operator):
         else:
             mat = bpy.data.materials.new(f"{new_obj.name}_Mat")
             mat.use_nodes = True
-            mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+            bsdf = mat.node_tree.nodes.get("Principled BSDF")
+            if bsdf:
+                bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
             new_curve.materials.append(mat)
         
         new_curve.bevel_depth = curve.bevel_depth if curve.bevel_depth > 0 else 0.002
@@ -2646,7 +2648,9 @@ class home_builder_details_OT_offset_curve(bpy.types.Operator):
         else:
             mat = bpy.data.materials.new(f"{self._preview_obj.name}_Mat")
             mat.use_nodes = True
-            mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = (0, 0, 0, 1)
+            bsdf = mat.node_tree.nodes.get("Principled BSDF")
+            if bsdf:
+                bsdf.inputs["Base Color"].default_value = (0, 0, 0, 1)
             new_curve.materials.append(mat)
         
         new_curve.bevel_depth = curve.bevel_depth if curve.bevel_depth > 0 else 0.002

--- a/operators/layouts.py
+++ b/operators/layouts.py
@@ -1964,7 +1964,9 @@ class home_builder_layouts_OT_draw_line(bpy.types.Operator, hb_placement.Placeme
         # Create material
         mat = bpy.data.materials.new("Line_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = line_color
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = line_color
         curve.materials.append(mat)
         
         curve.bevel_depth = line_thickness
@@ -2651,7 +2653,9 @@ class home_builder_layouts_OT_draw_rectangle(bpy.types.Operator, hb_placement.Pl
         # Create material
         mat = bpy.data.materials.new("Rectangle_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = line_color
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = line_color
         curve.materials.append(mat)
         
         curve.bevel_depth = line_thickness
@@ -3197,7 +3201,9 @@ class home_builder_layouts_OT_draw_circle(bpy.types.Operator, hb_placement.Place
         # Create material
         mat = bpy.data.materials.new("Circle_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = line_color
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = line_color
         curve.materials.append(mat)
         
         curve.bevel_depth = line_thickness
@@ -3636,7 +3642,9 @@ class home_builder_layouts_OT_add_text(bpy.types.Operator, hb_placement.Placemen
         # Create material
         mat = bpy.data.materials.new("Text_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = color
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = color
         text_data.materials.append(mat)
         
         # Set extrude for visibility

--- a/operators/ops_obstacles.py
+++ b/operators/ops_obstacles.py
@@ -275,8 +275,10 @@ class home_builder_obstacles_OT_place_obstacle(bpy.types.Operator, hb_placement.
         # Create material
         mat = bpy.data.materials.new(f"{obs_data[1]}_Mat")
         mat.use_nodes = True
-        mat.node_tree.nodes["Principled BSDF"].inputs["Base Color"].default_value = color
-        mat.node_tree.nodes["Principled BSDF"].inputs["Alpha"].default_value = 0.8
+        bsdf = mat.node_tree.nodes.get("Principled BSDF")
+        if bsdf:
+            bsdf.inputs["Base Color"].default_value = color
+            bsdf.inputs["Alpha"].default_value = 0.8
         mat.blend_method = 'BLEND'
         self.obstacle_obj.data.materials.append(mat)
         


### PR DESCRIPTION
Fix KeyError when Principled BSDF node has translated name (#4)

Replace all unsafe nodes["Principled BSDF"] direct accesses with
nodes.get("Principled BSDF") + guard, preventing KeyError when
Blender uses a non-English language setting that translates node names.

Fixed 14 occurrences across 5 files: hb_details.py, hb_layouts.py,
operators/ops_obstacles.py, operators/layouts.py, operators/details.py.
