### PR TITLE
Blender 5.2: finish the modifier-input migration (interior splitting, prompt dialogs)

### DIFF
--- a/product_libraries/face_frame/operators/ops_cabinet.py
+++ b/product_libraries/face_frame/operators/ops_cabinet.py
@@ -2281,6 +2281,8 @@ def _read_cage_dims(obj):
     """Return cage_dim_x/y/z dict by reading 'Dim X/Y/Z' inputs off the
     object's geometry node modifier. Used by the split operator to seed
     the new children's sizes from the active target's current rect.
+
+    Reads via hb_utils: a modifier isn't an ID property container on 5.2.
     """
     rect = {'cage_dim_x': 0.0, 'cage_dim_y': 0.0, 'cage_dim_z': 0.0}
     nm = next((m for m in obj.modifiers if m.type == 'NODES'), None)
@@ -2290,11 +2292,11 @@ def _read_cage_dims(obj):
         if sk.in_out != 'INPUT':
             continue
         if sk.name == 'Dim X':
-            rect['cage_dim_x'] = nm.get(sk.identifier, 0.0) or 0.0
+            rect['cage_dim_x'] = hb_utils.try_get_gn_input(nm, sk.identifier, 0.0) or 0.0
         elif sk.name == 'Dim Y':
-            rect['cage_dim_y'] = nm.get(sk.identifier, 0.0) or 0.0
+            rect['cage_dim_y'] = hb_utils.try_get_gn_input(nm, sk.identifier, 0.0) or 0.0
         elif sk.name == 'Dim Z':
-            rect['cage_dim_z'] = nm.get(sk.identifier, 0.0) or 0.0
+            rect['cage_dim_z'] = hb_utils.try_get_gn_input(nm, sk.identifier, 0.0) or 0.0
     return rect
 
 

--- a/product_libraries/frameless/operators/ops_front.py
+++ b/product_libraries/frameless/operators/ops_front.py
@@ -37,10 +37,17 @@ class hb_frameless_OT_door_front_prompts(bpy.types.Operator):
         wm = context.window_manager
         return wm.invoke_props_dialog(self, width=300)
 
+    def tag_front(self):
+        """5.2 modifier-input writes don't tag; rebuild the front."""
+        if self.front:
+            self.front.update_tag()
+
     def check(self, context):
+        self.tag_front()
         return True
 
     def execute(self, context):
+        self.tag_front()
         return {'FINISHED'}
 
     def draw(self, context):

--- a/product_libraries/frameless/operators/ops_interior.py
+++ b/product_libraries/frameless/operators/ops_interior.py
@@ -232,7 +232,17 @@ class hb_frameless_OT_interior_part_prompts(bpy.types.Operator):
         wm = context.window_manager
         return wm.invoke_props_dialog(self, width=300)
 
+    def tag_part(self, context):
+        """5.2 modifier-input writes don't tag; rebuild the part."""
+        if context.object:
+            context.object.update_tag()
+
+    def check(self, context):
+        self.tag_part(context)
+        return True
+
     def execute(self, context):
+        self.tag_part(context)
         return {'FINISHED'}
 
     def draw(self, context):


### PR DESCRIPTION
## Summary

### Problem

Three passes moved geometry-node modifier-input access into `hb_utils` for Blender 5.2 and converted around 76 call sites. Two things were left behind.

**One read was missed.** `_read_cage_dims` reads the cage's `Dim X/Y/Z` with `nm.get(identifier, 0.0)`. On 5.2 a modifier is not an ID-property container at all, so `.get()` raises instead of returning its default:

```
bpy.ops.hb_face_frame.add_interior_division(target_name='Opening 1')
  ops_cabinet.py:2343 _split_active_region
  ops_cabinet.py:2293 _read_cage_dims
TypeError: this type doesn't support IDProperties
```

It escaped the earlier passes because the search shape was `mod[...]` while the defect is `nm.get(k, default)` — which reads as safe.

**The API the passes moved *to* does not tag the object.** A modifier-input RNA property carries no update callback, and it is not an ID property, so the tag-on-write fallback that made the 5.1 `mod["Socket_2"]` write land does not fire.

### Why It's Important

`_split_active_region` is the only thing that builds an interior split tree, so on 5.2 no opening can be divided at all — both **Add… > Division** and **Add… > Fixed Shelf** throw and do nothing. The whole interior-tree feature is unreachable.

The missing tag is quieter and worse to diagnose: the two dialogs that draw modifier inputs directly — a 5-piece door's **Frame Sizes** and **Interior Part** properties — accept a number, store it, and leave the geometry exactly as it was. Nothing errors, so it reads as the value being ignored.

### Solution

The three reads now go through `hb_utils.try_get_gn_input`, the same shape as the already-migrated twin in `face_frame/split_preview.py:_cage_dims`. Its `<= 5.1` branch is that same `nm.get(identifier, default)`.

Both dialogs now tag the object they edit, in `check()` and again in `execute()` — the same reason `hb_types.set_input` calls `update_tag()`, as documented at `hb_types.py:356-360`. `check()` is where the sibling `interior_prompts` already does its per-edit work.

## Before / After

Measured on Blender 5.2.0 LTS against `bd22b22`.

| | Before (`main`) | After (this PR) |
|---|---|---|
| **Add… > Division** | `TypeError: this type doesn't support IDProperties` | `FINISHED`, 2 regions |
| **Add… > Fixed Shelf** | same `TypeError` | `FINISHED`, 2 regions |
| **Interior Part dialog**, `Mirror X` | value stored, mesh stays `x (0.0, 0.8699)` | mesh rebuilds to `x (-0.8699, 0.0)` |
| **5-piece door Frame Sizes** | stile width accepted, front unchanged | front rebuilds |
| `verify_52.py` | **0/3 PASS** | **3/3 PASS** |
| Regression control, 92 objects | — | byte-identical to `main` |

The regression control builds a room plus base / tall / upper / lap-drawer cabinets and a face-frame base, each through `run_calc_fix`, and dumps every evaluated mesh's vertex count and bounding box. Normal product construction does not move.

By hand, if you prefer the script: place a face-frame base cabinet and use **Add… > Division** on an opening (was a traceback, now two regions). Open a 5-piece door's **Frame Sizes** and change a stile width (was inert).

<details>
<summary><code>verify_52.py</code> — prints 0/3 on <code>main</code> and 3/3 here, ~40 s, no GUI</summary>

```python
"""Checks the two Blender 5.2 fixes. Prints 0/3 on main and 3/3 on the branch."""
import bpy

bpy.ops.preferences.addon_enable(module="bl_ext.blender_org.home_builder_5")
from bl_ext.blender_org.home_builder_5 import hb_utils
from bl_ext.blender_org.home_builder_5.product_libraries.face_frame \
    import types_face_frame
from bl_ext.blender_org.home_builder_5.product_libraries.frameless \
    import types_frameless

print("Blender", bpy.app.version_string, "| inputs as RNA:",
      hb_utils.GN_INPUTS_AS_RNA)
results = []


def check(name, fn):
    try:
        ok, detail = fn()
    except Exception as e:
        ok, detail = False, "%s: %s" % (type(e).__name__,
                                        str(e).splitlines()[0][:70])
    results.append(ok)
    print("  %-4s %-40s %s" % ("PASS" if ok else "FAIL", name, detail))


def opening():
    """A face frame base cabinet's first opening cage."""
    bpy.ops.wm.read_homefile(use_empty=True)
    bpy.ops.home_builder.create_room()
    cab = types_face_frame.BaseFaceFrameCabinet()
    cab.create("Base Cabinet")
    try:
        types_face_frame.recalculate_face_frame_cabinet(cab.obj)
    except Exception:
        pass
    op = next(o for o in bpy.data.objects
              if o.get('IS_FACE_FRAME_OPENING_CAGE'))
    bpy.context.view_layer.objects.active = op
    return op


def split(op_name):
    def run():
        op = opening()
        r = getattr(bpy.ops.hb_face_frame, op_name)(target_name=op.name)
        kids = [c.name for c in op.children]
        return bool(kids), "%s -> %d regions" % (r, len(kids))
    return run


def prompt_edit():
    """Write an input the way layout.prop() does in the part dialog, then
    click OK, and see whether the evaluated mesh moved."""
    bpy.ops.wm.read_homefile(use_empty=True)
    bpy.ops.home_builder.create_room()
    cab = types_frameless.BaseCabinet()
    cab.create("Base Cabinet")
    hb_utils.run_calc_fix(bpy.context, cab.obj)
    hb_utils.run_calc_fix(bpy.context, cab.obj)
    part = next(o for o in bpy.data.objects
                if 'IS_FRAMELESS_INTERIOR_PART' in o)
    bpy.context.view_layer.objects.active = part
    part.select_set(True)

    def span():
        dg = bpy.context.evaluated_depsgraph_get()
        ev = part.evaluated_get(dg)
        me = ev.to_mesh()
        xs = [v.co.x for v in me.vertices]
        out = (round(min(xs), 4), round(max(xs), 4))
        ev.to_mesh_clear()
        return out

    mod = part.modifiers[part.home_builder.mod_name]
    ident = mod.node_group.interface.items_tree["Mirror X"].identifier
    ref = hb_utils.gn_input_ui_ref(mod, ident)
    before = span()
    setattr(ref[0], ref[1], True)                      # the widget write
    bpy.ops.hb_frameless.interior_part_prompts('EXEC_DEFAULT')   # OK
    after = span()
    return after != before, "x %s -> %s" % (before, after)


print("\nchecks")
check("Add Interior > Division", split("add_interior_division"))
check("Add Interior > Fixed Shelf", split("add_interior_fixed_shelf"))
check("Part prompt edit reaches the geometry", prompt_edit)
print("\n%d/%d PASS" % (sum(results), len(results)))
```
</details>

## Changes Description

Two commits, 3 files, +22 / −3. No version bump, no manifest change, nothing in `hb_utils` or `hb_types`.

**`Blender 5.2: the interior split read cage dims as ID properties`**

- `product_libraries/face_frame/operators/ops_cabinet.py` — `_read_cage_dims`: the three `nm.get(sk.identifier, 0.0)` reads become `hb_utils.try_get_gn_input(nm, sk.identifier, 0.0)`, and the docstring gains a line saying why.

**`Blender 5.2: prompt dialog edits changed values without rebuilding`**

- `product_libraries/frameless/operators/ops_front.py` — `door_front_prompts`: new `tag_front()`, called from `check()` and `execute()`.
- `product_libraries/frameless/operators/ops_interior.py` — `interior_part_prompts`: new `tag_part()`, called from a new `check()` and from `execute()`.

## Compatibility

`blender_version_min` is `5.0.0`, and both edits are version-safe by construction — but I only have 5.2 here, so this leg is argued rather than tested:

- `try_get_gn_input` on `< 5.2` executes `return mod.get(identifier, default)`, which is literally the expression it replaces, plus a falsy-identifier guard that can only help.
- `obj.update_tag()` is a no-op on `< 5.2`, where the ID-property write already tagged.

Nothing here touches persisted data, driver paths, node groups or the shipped `.blend` assets, so there is no migration story.

## Two notes

This does not touch the `TypeError` from #24 — `main` already fixes that, in `ae34e6d` / `2778a96` / `5f72037`. What the reporter is hitting is that the newest tag, v5.1.2, predates those commits, so what he needs is a release rather than a code change.

The same sweep also turned up three defects unrelated to 5.2 — `Apply Settings to All` writing hardcoded socket identifiers onto door swings instead of dimensions, `_copy_geo_value_inputs` iterating a node-group interface while writing to it and silently dropping inputs, and `change_interior_type` deleting an interior it then fails to rebuild. I left them out to keep this focused; happy to open issues or a separate PR if useful.
