### PR TITLE
Fix three crash / data-loss paths in annotations, door duplication and interior change

### DIFF
--- a/operators/doors_windows.py
+++ b/operators/doors_windows.py
@@ -1679,7 +1679,10 @@ def _copy_geo_value_inputs(src_geo, dst_geo):
     """Copy every parametric (non-geometry) input from one GeoNode object onto
     another, matched by socket name. Geometry sockets and sockets missing on
     either node group are skipped. Clones a placed door/window's edited state
-    onto its duplicate."""
+    onto its duplicate.
+
+    The item list is materialized: set_input's interface_update rebuilds it.
+    """
     try:
         src_mod = src_geo.obj.modifiers[src_geo.obj.home_builder.mod_name]
         dst_mod = dst_geo.obj.modifiers[dst_geo.obj.home_builder.mod_name]
@@ -1688,9 +1691,6 @@ def _copy_geo_value_inputs(src_geo, dst_geo):
     if not src_mod.node_group or not dst_mod.node_group:
         return
     src_tree = src_mod.node_group.interface.items_tree
-    # Materialized: set_input runs interface_update on the first write of an
-    # input name, which rebuilds the interface item list and invalidates a live
-    # iterator over it - inputs after that point are skipped or the walk dies.
     for item in list(dst_mod.node_group.interface.items_tree):
         if getattr(item, 'item_type', '') != 'SOCKET':
             continue

--- a/operators/doors_windows.py
+++ b/operators/doors_windows.py
@@ -1688,7 +1688,10 @@ def _copy_geo_value_inputs(src_geo, dst_geo):
     if not src_mod.node_group or not dst_mod.node_group:
         return
     src_tree = src_mod.node_group.interface.items_tree
-    for item in dst_mod.node_group.interface.items_tree:
+    # Materialized: set_input runs interface_update on the first write of an
+    # input name, which rebuilds the interface item list and invalidates a live
+    # iterator over it - inputs after that point are skipped or the walk dies.
+    for item in list(dst_mod.node_group.interface.items_tree):
         if getattr(item, 'item_type', '') != 'SOCKET':
             continue
         if getattr(item, 'in_out', '') != 'INPUT':

--- a/ops.py
+++ b/ops.py
@@ -6,6 +6,7 @@ from mathutils import Vector
 from gpu_extras.batch import batch_for_shader
 from bpy_extras.view3d_utils import region_2d_to_location_3d, location_3d_to_region_2d
 import bmesh
+from . import hb_types
 from . import hb_utils
 
 class home_builder_OT_to_do(bpy.types.Operator):
@@ -169,24 +170,16 @@ class home_builder_annotations_OT_apply_settings_to_all(bpy.types.Operator):
                 
                 texts_updated += 1
             
-            # Update dimensions
-            elif obj.get('IS_2D_ANNOTATION') and obj.type == 'MESH':
-                for mod in obj.modifiers:
-                    if mod.type == 'NODES' and mod.node_group:
-                        try:
-                            hb_utils.set_gn_input(mod, 'Socket_3', hb_scene.annotation_dimension_text_size)
-                        except (KeyError, AttributeError):
-                            pass
-                        try:
-                            hb_utils.set_gn_input(mod, 'Socket_4', hb_scene.annotation_dimension_tick_length)
-                        except (KeyError, AttributeError):
-                            pass
-                        try:
-                            hb_utils.set_gn_input(mod, 'Socket_5', hb_scene.annotation_dimension_line_thickness)
-                        except (KeyError, AttributeError):
-                            pass
-                
-                dimensions_updated += 1
+            # Update dimensions by input name; hardcoded sockets hit swings.
+            elif obj.get('IS_DIMENSION'):
+                dim = hb_types.GeoNodeDimension(obj)
+                if dim.has_modifier():
+                    dim.set_input("Text Size", hb_scene.annotation_dimension_text_size)
+                    dim.set_input("Tick Length", hb_scene.annotation_dimension_tick_length)
+                    dim.set_input("Line Thickness", hb_scene.annotation_dimension_line_thickness)
+                    dim.set_input("Tick Thickness", hb_scene.annotation_dimension_tick_thickness)
+
+                    dimensions_updated += 1
         
         total = lines_updated + texts_updated + dimensions_updated
         self.report({'INFO'}, f"Updated {total} annotations ({lines_updated} lines, {texts_updated} texts, {dimensions_updated} dimensions)")

--- a/product_libraries/frameless/operators/ops_interior.py
+++ b/product_libraries/frameless/operators/ops_interior.py
@@ -169,7 +169,7 @@ class hb_frameless_OT_change_interior_type(bpy.types.Operator):
 
     def add_interior_to_opening(self, opening_obj, interior):
         """Add an interior to an opening with proper drivers."""
-        interior.create()
+        interior.create('Interior')
         interior.obj.parent = opening_obj
         
         if 'IS_FRAMELESS_OPENING_CAGE' in opening_obj:


### PR DESCRIPTION
## Summary

### Problem

Three defects found while auditing the Blender 5.2 modifier-input work. None of them is 5.2 related — each fails the same way on 5.1 — so they are split out from #26.

**`Apply Settings to All` has never updated a dimension.** The branch selects meshes tagged `IS_2D_ANNOTATION`, but dimensions are curves (`GeoNodeDimension` uses `create_curve`), so it has never matched one. What it does match is `GeoNodeDoorSwing`, the only mesh in the addon carrying that tag, where `Socket_3` is `Dim Y` and `Socket_4` is the boolean `Is Double`.

**Duplicating a door loses part of its state.** `_copy_geo_value_inputs` iterates the node group's interface while writing to it, and `set_input` runs `interface_update` on the first write of an unresolved input name — which rebuilds the list the iterator is walking.

**`Interior > Shelves` deletes the interior and rebuilds nothing.** `add_interior_to_opening` calls `interior.create()` with no argument; `CabinetShelves.create` requires a name.

### Why It's Important

Each one loses user work silently or destructively.

The annotations button writes the annotation text size into every door swing's depth — measured `0.9 → 0.077`, with no driver to restore it. On 5.2 it then raises `TypeError: Socket_4.value expected True/False or 0/1, not float` writing a float into that boolean, which the `(KeyError, AttributeError)` guard does not catch, so the operator aborts and every annotation it had not reached yet is skipped. Meanwhile the thing the button is named for has never worked.

Duplicating a door is the one operation whose whole purpose is preserving the source's edited state, and it returns a copy with the swing quietly wrong. Nothing errors, so it reads as the user having set it up wrong.

`Interior > Shelves` is reachable from the interior cage's own right-click menu, and `execute()` deletes before it builds — so when the call raises, the interior and every shelf under it are already gone.

### Solution

The annotations branch now selects `IS_DIMENSION` and writes by input name through `hb_types.GeoNodeDimension`, exactly as the sliders in `hb_props` already do, so socket numbering no longer matters and mesh annotations are left alone. Widening the guard instead would have been worse: the loop would run on and write the text size into *every* door swing rather than stopping at the first.

The copy loop materialises the interface list before walking it. That cannot be invalidated, and costs nothing.

`add_interior_to_opening` passes `'Interior'`, the same name the cabinet build path uses in `types_frameless.add_interior`.

## Before / After

Measured on Blender 5.2.0 LTS against `bd22b22`.

| | Before (`main`) | After (this PR) |
|---|---|---|
| **Apply Settings to All**, scene with a door | `TypeError` → operator aborts | `FINISHED` |
| **…** the dimension it is named for | `Text Size` stays `0.0100` | `Text Size` = `0.0770` |
| **…** the door swing | `Dim Y` `0.9 → 0.077`, permanent | `Dim Y` stays `0.9` |
| **Duplicate Door** | `lost=['Is Double', 'Swing Inside']` | `lost=[]` |
| **Interior > Shelves** | `RuntimeError`, `interiors=[]` | `interiors=['Interior']` |
| `verify_fixes.py` | **0/5 PASS** | **5/5 PASS** |
| Regression control, 92 objects | — | byte-identical to `main` |

The regression control builds a room plus base / tall / upper / lap-drawer cabinets and a face-frame base, each through `run_calc_fix`, and dumps every evaluated mesh's vertex count and bounding box. Normal product construction does not move.

<details>
<summary><code>verify_fixes.py</code> — prints 0/5 on <code>main</code> and 5/5 here, no GUI</summary>

```python
"""Checks the three crash / data-loss fixes. 0/5 on main, 5/5 on the branch."""
import bpy

bpy.ops.preferences.addon_enable(module="bl_ext.blender_org.home_builder_5")
from bl_ext.blender_org.home_builder_5 import hb_types, hb_utils
from bl_ext.blender_org.home_builder_5.operators import doors_windows
from bl_ext.blender_org.home_builder_5.product_libraries.frameless \
    import types_frameless

print("Blender", bpy.app.version_string, "| inputs as RNA:",
      hb_utils.GN_INPUTS_AS_RNA)
results = []


def check(name, fn):
    try:
        ok, detail = fn()
    except Exception as e:
        ok, detail = False, "%s: %s" % (type(e).__name__,
                                        str(e).splitlines()[0][:70])
    results.append(ok)
    print("  %-4s %-42s %s" % ("PASS" if ok else "FAIL", name, detail))


def annotation_scene():
    """Settings first: the hb_props sliders push to every dimension on write,
    so setting them afterwards would measure the slider, not the operator."""
    bpy.ops.wm.read_homefile(use_empty=True)
    bpy.ops.home_builder.create_room()
    sc = bpy.context.scene.home_builder
    sc.annotation_dimension_text_size = 0.077
    sc.annotation_dimension_tick_length = 0.041
    sc.annotation_dimension_line_thickness = 0.0041

    dim = hb_types.GeoNodeDimension()
    dim.create("Dim")
    swing = hb_types.GeoNodeDoorSwing()
    swing.create("Swing")
    dim.set_input("Text Size", 0.010)      # knock the dimension out of sync
    swing.set_input("Dim Y", 0.9)          # the swing must not be touched
    return dim, swing


def apply_finishes():
    annotation_scene()
    r = bpy.ops.home_builder_annotations.apply_settings_to_all()
    return True, str(r)


def apply_updates_dim():
    dim, _ = annotation_scene()
    try:
        bpy.ops.home_builder_annotations.apply_settings_to_all()
    except Exception:
        pass
    got = round(dim.get_input("Text Size"), 4)
    return abs(got - 0.077) < 1e-4, "Text Size=%.4f want 0.0770" % got


def apply_spares_swing():
    _, swing = annotation_scene()
    try:
        bpy.ops.home_builder_annotations.apply_settings_to_all()
    except Exception:
        pass
    got = round(swing.get_input("Dim Y"), 4)
    return abs(got - 0.9) < 1e-4, "swing Dim Y=%.4f want 0.9000" % got


def duplicate_keeps_state():
    bpy.ops.wm.read_homefile(use_empty=True)
    bpy.ops.home_builder.create_room()
    src = hb_types.GeoNodeDoorSwing()
    src.create("SwingSrc")
    for n in ("Is Double", "Swing Inside", "Is Left"):
        src.set_input(n, True)
    dst = hb_types.GeoNodeDoorSwing()
    dst.create("SwingDst")
    # a reopened file has nothing cached, which is what makes set_input run
    # interface_update inside the copy loop
    hb_types._INPUT_IDENT_CACHE.clear()
    doors_windows._copy_geo_value_inputs(src, dst)
    lost = [n for n in ("Is Double", "Swing Inside", "Is Left")
            if not dst.get_input(n)]
    return not lost, "lost=%s" % (lost or "[]")


def interior_survives():
    bpy.ops.wm.read_homefile(use_empty=True)
    bpy.ops.home_builder.create_room()
    cab = types_frameless.BaseCabinet()
    cab.create("Base Cabinet")
    hb_utils.run_calc_fix(bpy.context, cab.obj)
    obj = next(o for o in bpy.data.objects
               if 'IS_FRAMELESS_INTERIOR_CAGE' in o)
    bpy.context.view_layer.objects.active = obj
    obj.select_set(True)
    try:
        bpy.ops.hb_frameless.change_interior_type(interior_type='SHELVES')
    except Exception as e:
        after = [o.name for o in bpy.data.objects
                 if 'IS_FRAMELESS_INTERIOR_CAGE' in o]
        return False, "%s; interiors=%s" % (type(e).__name__, after)
    after = [o.name for o in bpy.data.objects
             if 'IS_FRAMELESS_INTERIOR_CAGE' in o]
    return bool(after), "interiors=%s" % after


print("\nchecks")
check("Apply Settings to All finishes", apply_finishes)
check("  ... updates the dimension", apply_updates_dim)
check("  ... leaves the door swing alone", apply_spares_swing)
check("Duplicate keeps the whole swing state", duplicate_keeps_state)
check("Interior > Shelves keeps the interior", interior_survives)
print("\n%d/%d PASS" % (sum(results), len(results)))
```
</details>

By hand: place a door, save, reopen, **Duplicate Door**, check the swing hand survived. Right-click an interior cage > **Change Interior > Shelves**. With a door in the scene, press **Apply Settings to All**.

## Changes Description

Three commits, 3 files, +17 / −21.

**`Annotations: Apply Settings to All never updated a dimension`**

- `ops.py` — `home_builder_annotations_OT_apply_settings_to_all`: the dimension branch selects `IS_DIMENSION` instead of `IS_2D_ANNOTATION and type == 'MESH'`, and writes `Text Size` / `Tick Length` / `Line Thickness` / `Tick Thickness` by name through `hb_types.GeoNodeDimension`, guarded by `has_modifier()`. Adds `from . import hb_types` — no cycle, `hb_types` imports only `units` and `hb_utils`. `dimensions_updated` now counts real dimensions.

**`Duplicating a door or window dropped part of the source's state`**

- `operators/doors_windows.py` — `_copy_geo_value_inputs`: wraps the iterated `items_tree` in `list()`, with a line in the docstring saying why.

**`Interior > Shelves deleted the interior and rebuilt nothing`**

- `product_libraries/frameless/operators/ops_interior.py` — `change_interior_type.add_interior_to_opening`: `interior.create()` becomes `interior.create('Interior')`.

## Compatibility

`blender_version_min` is `5.0.0`. None of the three edits is version-dependent, and none is 5.2 specific — but I only have 5.2 here, so this leg is argued rather than tested:

- `hb_types.GeoNodeDimension.set_input` routes to `mod[ident] = value` on `< 5.2`, the path the `hb_props` sliders already use on every version. It also stops depending on `Socket_N` numbering, which was the version-independent half of that bug.
- `list(...)` and `create('Interior')` are plain Python.

`IS_DIMENSION` has exactly one setter in the codebase (`hb_types.py:723`, in `GeoNodeDimension.create`), so the new selector can only ever match a real dimension. Nothing here touches persisted data, driver paths, node groups or the shipped `.blend` assets. No version bump, no manifest change, nothing in `hb_utils` or `hb_types`.

## Two notes

`Interior > Shelves` makes a code path run for the first time. After the rebuild, `update_shelf_quantities` applies its own default, which took my test cabinet from 1 shelf to 2 — a pre-existing disagreement between the build path and this operator, not something this change introduces. Worth knowing before you merge.

On the copy loop: an instrumented walk also yielded a NULL item at the end, and a separate run took Blender down at `NodeTreeInterface_items_tree_next` / `pyrna_prop_collection_iter_next`. **I did not reproduce the crash myself** and am not claiming it — I am only reporting the silent input loss I measured, with the crash as a possible consequence of the same use-after-free walk.
