### PR TITLE
wall snap line hardcoded as inches

### DIFF
--- a/product_libraries/frameless/operators/ops_snap_line.py
+++ b/product_libraries/frameless/operators/ops_snap_line.py
@@ -225,8 +225,19 @@ class hb_frameless_OT_place_snap_line(bpy.types.Operator):
             self.cancel_typing()
             return
         
-        value_meters = units.inch(value)
-        
+        # Plain typed numbers are interpreted using the scene's unit
+        # system, matching how other placement operators (doors/windows)
+        # parse typed distances - not hardcoded to inches.
+        unit_settings = context.scene.unit_settings
+        if unit_settings.system == 'IMPERIAL':
+            value_meters = units.inch(value)
+        elif unit_settings.length_unit == 'MILLIMETERS':
+            value_meters = units.millimeter(value)
+        elif unit_settings.length_unit == 'CENTIMETERS':
+            value_meters = units.centimeter(value)
+        else:
+            value_meters = value  # meters
+
         if self.typing_target == 'LEFT':
             self.set_snap_position(value_meters)
         elif self.typing_target == 'RIGHT':


### PR DESCRIPTION
## Bug
Typing a plain number while placing a Wall > Snap Line (e.g. "3.15" for
3.15 from the left) doesn't stay where you type it - it lands way off,
close to the start of the wall instead.

## Cause
`apply_typed_value` always ran the typed number through `units.inch()`
regardless of the scene's unit system. On a metric scene, typing "3.15"
was read as 3.15 inches (~8cm) instead of 3.15m.

## Fix
Respect `scene.unit_settings` the same way plain-number input is handled
elsewhere in the codebase - imperial stays inches, metric converts based
on `length_unit` (mm/cm/m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)