### PR TITLE
feat: add experimental semantic lines module

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,6 +37,7 @@ from . import molding
 from . import hb_layouts
 from . import hb_assets
 from . import hb_snap_engine
+from . import semantic_lines
 
 from bpy.app.handlers import persistent
 
@@ -341,6 +342,7 @@ def register():
     hb_props.register()
     hb_project.register()
     hb_snap_engine.register()
+    semantic_lines.register()
     hb_props_obstacles.register()
     ops_obstacles.register()
     walls.register()
@@ -393,6 +395,7 @@ def unregister():
     hb_props.unregister()
     hb_project.unregister()
     hb_snap_engine.unregister()
+    semantic_lines.unregister()
     hb_props_obstacles.unregister()
     ops_obstacles.unregister()
     walls.unregister()

--- a/docs/semantic_lines/CONTRIBUTING.md
+++ b/docs/semantic_lines/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Semantic Lines Contribution Conventions
+
+## Design rules
+
+1. Extract semantic edges once; do not add a separate edge-discovery path for
+   viewport, rendering, drafting, or picking.
+2. Faces and triangles are visibility evidence only. Internal tessellation
+   must not become visible technical linework by accident.
+3. Keep geometry in model/world space and projected edges in 2D space. Do not
+   persist raster pixels as geometry or measurement data.
+4. New consumers accept `SemanticEdge` or `ProjectedEdgeSegment`; they must
+   not depend on a particular viewport or compositor implementation.
+5. Preserve existing Home Builder wireframe, Line Art, and Freestyle behavior
+   unless the user explicitly enables Semantic Lines.
+
+## Visibility conventions
+
+- Use scale-aware self-occlusion tolerances.
+- Split at visibility transitions. For sampled changes at an edge endpoint,
+  snap the transition to the endpoint so solid strokes do not overdraw a
+  hidden corner.
+- Suppress a hidden line only when visible collinear segments cover its entire
+  projected length. Do not suppress merely nearby or partially overlapping
+  linework.
+- Keep dash generation in screen/image space so it is independent of mesh
+  segmentation.
+
+## UI and settings conventions
+
+- Add user controls under **Semantic Edges (Experimental)** as a child panel.
+- Put shared visual controls in **Edge Control**. A consumer may add an
+  explicitly named multiplier for calibration, but must not introduce an
+  unrelated duplicate color or base-weight setting.
+- Scene properties use the `hb_semantic_edge_` or `hb_semantic_render_`
+  prefix. Blender data blocks and compositor nodes use the `HB Semantic`
+  prefix.
+
+## Tests and verification
+
+Run:
+
+```bat
+scripts\run_tests.cmd
+```
+
+Every semantic feature needs a Blender-headless test. At minimum cover a
+box, coplanar triangulation, sharp fold, marked edge, visibility-run boundary,
+and the render pass when applicable. Add a visual regression fixture before
+changing line style, dashing, or visibility semantics.
+
+Before upstream review, rebuild the portable extension with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\install_dev_extension.ps1
+```
+
+Then check both an orthographic isometric viewport and an F12 layout render.

--- a/docs/semantic_lines/README.md
+++ b/docs/semantic_lines/README.md
@@ -1,0 +1,64 @@
+# Semantic Lines
+
+Semantic Lines is an **experimental, opt-in** technical-line subsystem for
+Home Builder. It is an alternative to wireframe-based edge display: it
+derives intentional model edges once and provides them to viewport and render
+consumers without treating Freestyle, Grease Pencil, or curve objects as the
+authoritative edge model.
+
+It is disabled by default. Enable **Show Overlay** in **Home Builder →
+Semantic Edges (Experimental) → Edge Control**. The optional render pass is
+also disabled until its own toggle is enabled.
+
+## Current components
+
+| Component | Responsibility |
+| --- | --- |
+| `semantic_lines/semantic_edges.py` | Extracts `SemanticEdge` records from evaluated meshes. |
+| `semantic_lines/semantic_edge_overlay.py` | Projects, classifies, and draws viewport lines. |
+| `semantic_lines/semantic_line_render.py` | Builds a camera-projected transparent render line pass and composites it. |
+| `tests/test_semantic_edges.py` | Blender-headless unit and integration coverage. |
+
+The `semantic_lines/` package is the module boundary. Its model, viewport,
+and render layers should change together only when a feature crosses those
+consumers.
+
+## Public data contract
+
+`SemanticEdge` is the source record. Its `uid` identifies an edge within an
+authored source object; `topology_edge_index` is a current-mesh convenience,
+not persistent identity. Consumers must retain `source_edge_uid`, never a
+rendered segment as the model reference.
+
+Semantic classes currently are `BOUNDARY`, `SHARP`, and `USER_MARKED`.
+Coplanar triangulation edges are excluded unless the mesh has the boolean
+EDGE-domain `hb_semantic_edge` attribute set for that edge.
+
+`ProjectedEdgeSegment` is consumer-neutral 2D data. It contains the source
+UID, two screen/image points, and `VISIBLE` or `HIDDEN` visibility. It stays
+analytic until a viewport or render consumer rasterizes it.
+
+## User behavior
+
+The **Semantic Edges (Experimental)** parent panel contains all controls:
+
+- **Edge Control** configures the viewport overlay and technical visibility.
+- **Line Rendering** configures the render-camera line pass.
+
+The shared color and line-weight controls are the source of truth. Viewport
+and render multipliers are deliberately secondary calibration controls.
+
+## Scope and non-goals
+
+Current hidden-line classification is sampled ray testing. It is suitable for
+the rectangular and low-poly interior models Home Builder primarily produces,
+but it is not yet an exact analytic hidden-line solver. Vector export, edge
+picking, and dimension references are planned consumers, not implemented
+features.
+
+## Upstream compatibility
+
+The system does not modify existing wireframe, Freestyle, or Grease Pencil
+Line Art architecture. It has independent scene settings and compositor nodes
+prefixed `HB Semantic Lines`. A submission must preserve existing layout
+rendering when the semantic overlay and render toggle are off.

--- a/semantic_lines/__init__.py
+++ b/semantic_lines/__init__.py
@@ -1,0 +1,20 @@
+"""Opt-in experimental Semantic Lines module for Home Builder.
+
+This package is deliberately self-contained so it can be reviewed, adopted,
+or removed independently of the established wireframe and Line Art workflows.
+"""
+
+from . import semantic_edge_overlay
+from . import semantic_line_render
+
+
+def register():
+    """Register the interactive and render consumers together."""
+    semantic_edge_overlay.register()
+    semantic_line_render.register()
+
+
+def unregister():
+    """Unregister in reverse dependency order."""
+    semantic_line_render.unregister()
+    semantic_edge_overlay.unregister()

--- a/semantic_lines/semantic_edge_overlay.py
+++ b/semantic_lines/semantic_edge_overlay.py
@@ -1,0 +1,702 @@
+"""First interactive consumer for :mod:`semantic_edges`.
+
+This intentionally small overlay proves the semantic-edge pipeline in the
+active 3D viewport.  It projects candidates into screen space and batches
+them for GPU drawing.  Visibility/hidden-line splitting is deliberately not
+part of this first slice: every selected semantic edge is drawn.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+
+import bpy
+import gpu
+from bpy.props import (BoolProperty, EnumProperty, FloatProperty,
+                       FloatVectorProperty, IntProperty)
+from mathutils import Vector
+from bpy_extras import view3d_utils
+from gpu_extras.batch import batch_for_shader
+
+try:  # Allows the Blender-headless tests to import this module directly.
+    from . import semantic_edges
+except ImportError:
+    import semantic_edges
+
+
+TEST_COLLECTION_NAME = "HB Semantic Edge Tests"
+# Screen-space, muted technical-ink styling.  POLYLINE_UNIFORM_COLOR keeps
+# this thickness stable when zooming and rasterizes considerably more cleanly
+# than the legacy GPU line-width state.
+OVERLAY_COLOR = (0.12, 0.19, 0.25, 0.92)
+OVERLAY_LINE_WIDTH = 1.25
+HIDDEN_COLOR = (0.12, 0.19, 0.25, 0.48)
+HIDDEN_LINE_WIDTH = 0.9
+HIDDEN_DASH_LENGTH = 5.0
+HIDDEN_GAP_LENGTH = 4.0
+ALIGNED_LINE_TOLERANCE = 1.0
+ALIGNED_COVERAGE_TOLERANCE = 0.02
+
+VISIBLE = 'VISIBLE'
+HIDDEN = 'HIDDEN'
+
+_draw_handle = None
+_projection_cache = {'key': None, 'segments': ()}
+_viewport_performance = {'backend': 'Waiting for redraw', 'edges': 0, 'samples': 0}
+_navigation_preview = {
+    'view_key': None,
+    'last_change': 0.0,
+    'settled': True,
+    'timer_pending': False,
+}
+# Extraction is independent of the viewport.  Keeping the world-space edge
+# list means orbiting, panning, and zooming do not repeatedly walk every mesh
+# topology in a furnished scene.
+_semantic_edge_cache = {'scene_pointer': None, 'by_object': {}}
+
+SCREEN_CULL_MARGIN = 2.0
+VISIBILITY_PIXELS_PER_SAMPLE = 96.0
+VISIBILITY_MIN_SAMPLES = 3
+HIDDEN_INDEX_CELL_SIZE = 128.0
+NAVIGATION_SETTLE_SECONDS = 0.18
+
+
+@dataclass(frozen=True)
+class ProjectedEdgeSegment:
+    """A screen-space portion of a semantic edge and its visibility."""
+
+    source_edge_uid: str
+    start: tuple[float, float]
+    end: tuple[float, float]
+    visibility: str
+
+
+def _redraw_viewports(_self=None, _context=None):
+    """Request a redraw after an overlay setting changes."""
+    for window in bpy.context.window_manager.windows:
+        for area in window.screen.areas:
+            if area.type == 'VIEW_3D':
+                area.tag_redraw()
+
+
+def _invalidate_projection_cache(_scene=None, _depsgraph=None):
+    _projection_cache['key'] = None
+    _projection_cache['segments'] = ()
+
+
+def _finish_navigation_preview():
+    """Request full hidden-line work only after viewport motion has stopped."""
+    state = _navigation_preview
+    if time.monotonic() - state['last_change'] < NAVIGATION_SETTLE_SECONDS:
+        return NAVIGATION_SETTLE_SECONDS
+    state['settled'] = True
+    state['timer_pending'] = False
+    _invalidate_projection_cache()
+    _redraw_viewports()
+    return None
+
+
+def _navigation_is_active(region, region_3d):
+    """Track changing view matrices and defer expensive hidden-line solving."""
+    state = _navigation_preview
+    view_key = (region.as_pointer(),
+                tuple(round(value, 7) for row in region_3d.perspective_matrix
+                      for value in row))
+    if state['view_key'] == view_key:
+        return not state['settled']
+    state['view_key'] = view_key
+    state['last_change'] = time.monotonic()
+    state['settled'] = False
+    if not state['timer_pending']:
+        state['timer_pending'] = True
+        bpy.app.timers.register(_finish_navigation_preview,
+                                first_interval=NAVIGATION_SETTLE_SECONDS)
+    return True
+
+
+def _invalidate_semantic_edge_cache(_scene=None, _depsgraph=None):
+    """Discard extracted edges only when evaluated mesh content changes."""
+    _invalidate_projection_cache()
+    _semantic_edge_cache['scene_pointer'] = None
+    _semantic_edge_cache['by_object'] = {}
+
+
+def _depsgraph_update_post(_scene, depsgraph):
+    """Avoid cache churn from unrelated Blender dependency-graph updates."""
+    for update in depsgraph.updates:
+        updated_id = update.id
+        if isinstance(updated_id, bpy.types.Mesh):
+            _invalidate_semantic_edge_cache()
+            return
+        if isinstance(updated_id, bpy.types.Object) and updated_id.type == 'MESH':
+            _invalidate_semantic_edge_cache()
+            return
+        # Collection visibility can change which mesh objects are candidates.
+        if isinstance(updated_id, bpy.types.Collection):
+            _invalidate_semantic_edge_cache()
+            return
+
+
+def line_color(scene):
+    """The user-selected technical-ink color, with a safe module fallback."""
+    return tuple(getattr(scene, 'hb_semantic_edge_line_color', OVERLAY_COLOR))
+
+
+def hidden_line_color(color):
+    """Keep hidden lines visually subordinate while preserving hue."""
+    hidden_alpha_ratio = HIDDEN_COLOR[3] / OVERLAY_COLOR[3]
+    return (color[0], color[1], color[2], color[3] * hidden_alpha_ratio)
+
+
+def viewport_line_width(scene):
+    return (getattr(scene, 'hb_semantic_edge_line_weight', OVERLAY_LINE_WIDTH)
+            * getattr(scene, 'hb_semantic_edge_viewport_weight_multiplier', 1.0))
+
+
+def render_line_width(scene):
+    return (getattr(scene, 'hb_semantic_edge_line_weight', OVERLAY_LINE_WIDTH)
+            * getattr(scene, 'hb_semantic_edge_render_weight_multiplier', 1.25))
+
+
+def hidden_line_width(visible_width):
+    return visible_width * (HIDDEN_LINE_WIDTH / OVERLAY_LINE_WIDTH)
+
+
+def _overlay_candidates(context):
+    selected_only = context.scene.hb_semantic_edges_selected_only
+    selected = set(context.selected_objects) if selected_only else None
+    return [obj for obj in context.scene.objects
+            if obj.type == 'MESH'
+            and obj.visible_get(view_layer=context.view_layer)
+            and (selected is None or obj in selected)]
+
+
+def _cached_semantic_edges(context, depsgraph):
+    """Return extracted edge lists for the current candidates without rebuilds."""
+    cache = _semantic_edge_cache
+    scene_pointer = context.scene.as_pointer()
+    if cache['scene_pointer'] != scene_pointer:
+        cache['scene_pointer'] = scene_pointer
+        cache['by_object'] = {}
+    edge_lists = []
+    for obj in _overlay_candidates(context):
+        object_pointer = obj.as_pointer()
+        edges = cache['by_object'].get(object_pointer)
+        if edges is None:
+            edges = tuple(semantic_edges.extract_semantic_edges(obj, depsgraph))
+            cache['by_object'][object_pointer] = edges
+        edge_lists.append(edges)
+    return edge_lists
+
+
+def visibility_runs(samples):
+    """Turn ordered samples into visible/hidden parameter intervals.
+
+    A visibility change between the first two or final two samples is snapped
+    to the edge endpoint. At a model corner the endpoint sample commonly sees
+    its own adjacent face while the next sample is genuinely occluded;
+    midpoint splitting would otherwise let the solid line overrun the corner.
+    """
+    if not samples:
+        return ()
+    if len(samples) == 1:
+        return ((0.0, 1.0, VISIBLE if samples[0] else HIDDEN),)
+    runs, state, start = [], samples[0], 0.0
+    last_index = len(samples) - 1
+    for index in range(1, len(samples)):
+        if samples[index] == state:
+            continue
+        if index == 1:
+            boundary = 0.0
+        elif index == last_index:
+            boundary = 1.0
+        else:
+            boundary = (index - 0.5) / last_index
+        if boundary > start:
+            runs.append((start, boundary, VISIBLE if state else HIDDEN))
+        state, start = samples[index], boundary
+    if start < 1.0:
+        runs.append((start, 1.0, VISIBLE if state else HIDDEN))
+    return tuple(runs)
+
+
+def dashed_screen_segments(start, end, dash_length=HIDDEN_DASH_LENGTH,
+                           gap_length=HIDDEN_GAP_LENGTH):
+    """Create deterministic dash segments in viewport pixels."""
+    dx, dy = end[0] - start[0], end[1] - start[1]
+    length = (dx * dx + dy * dy) ** 0.5
+    if length <= 1.0e-6:
+        return ()
+    ux, uy = dx / length, dy / length
+    out, position = [], 0.0
+    while position < length:
+        dash_end = min(position + dash_length, length)
+        out.append(((start[0] + ux * position, start[1] + uy * position),
+                    (start[0] + ux * dash_end, start[1] + uy * dash_end)))
+        position = dash_end + gap_length
+    return tuple(out)
+
+
+def hidden_segment_is_covered(hidden, visible_segments,
+                              line_tolerance=ALIGNED_LINE_TOLERANCE):
+    """True if visible collinear segments cover all of a hidden segment.
+
+    This is a screen-space drafting cleanup rule.  It only suppresses an
+    already-hidden segment, so a nearby parallel line or visible model detail
+    is never removed merely because it sits close to another line.
+    """
+    ax, ay = hidden.start
+    bx, by = hidden.end
+    dx, dy = bx - ax, by - ay
+    length_sq = dx * dx + dy * dy
+    if length_sq <= 1.0e-6:
+        return True
+    length = length_sq ** 0.5
+    intervals = []
+    for visible in visible_segments:
+        if visible.source_edge_uid == hidden.source_edge_uid:
+            continue
+        vx0, vy0 = visible.start
+        vx1, vy1 = visible.end
+        # Perpendicular distance of both endpoints from hidden's supporting
+        # line.  The threshold is in pixels and matches visual alignment.
+        distance0 = abs((vx0 - ax) * dy - (vy0 - ay) * dx) / length
+        distance1 = abs((vx1 - ax) * dy - (vy1 - ay) * dx) / length
+        if max(distance0, distance1) > line_tolerance:
+            continue
+        t0 = ((vx0 - ax) * dx + (vy0 - ay) * dy) / length_sq
+        t1 = ((vx1 - ax) * dx + (vy1 - ay) * dy) / length_sq
+        start, end = max(0.0, min(t0, t1)), min(1.0, max(t0, t1))
+        if end > start:
+            intervals.append((start, end))
+    if not intervals:
+        return False
+
+    intervals.sort()
+    covered_start, covered_end = intervals[0]
+    if covered_start > ALIGNED_COVERAGE_TOLERANCE:
+        return False
+    for start, end in intervals[1:]:
+        if start > covered_end + ALIGNED_COVERAGE_TOLERANCE:
+            return False
+        covered_end = max(covered_end, end)
+    return covered_end >= 1.0 - ALIGNED_COVERAGE_TOLERANCE
+
+
+def _segment_grid_cells(segment, cell_size=HIDDEN_INDEX_CELL_SIZE):
+    """Yield conservative screen-space grid cells occupied by a segment."""
+    min_x = min(segment.start[0], segment.end[0])
+    max_x = max(segment.start[0], segment.end[0])
+    min_y = min(segment.start[1], segment.end[1])
+    max_y = max(segment.start[1], segment.end[1])
+    start_x = int(min_x // cell_size)
+    end_x = int(max_x // cell_size)
+    start_y = int(min_y // cell_size)
+    end_y = int(max_y // cell_size)
+    for x in range(start_x, end_x + 1):
+        for y in range(start_y, end_y + 1):
+            yield (x, y)
+
+
+def suppress_aligned_hidden_segments(segments):
+    """Drop hidden segments fully coincident with visible technical lines."""
+    visible = [segment for segment in segments if segment.visibility == VISIBLE]
+    # The original drafting rule compared every hidden segment with every
+    # visible segment.  A coarse spatial index preserves the rule while
+    # making large cabinet/room scenes scale with nearby lines instead of all
+    # lines in the viewport.
+    visible_index = {}
+    for segment in visible:
+        for cell in _segment_grid_cells(segment):
+            visible_index.setdefault(cell, []).append(segment)
+
+    def nearby_visible(segment):
+        nearby, seen = [], set()
+        for cell in _segment_grid_cells(segment):
+            for candidate in visible_index.get(cell, ()):
+                pointer = id(candidate)
+                if pointer not in seen:
+                    seen.add(pointer)
+                    nearby.append(candidate)
+        return nearby
+
+    return tuple(segment for segment in segments
+                 if segment.visibility != HIDDEN
+                 or not hidden_segment_is_covered(segment, nearby_visible(segment)))
+
+
+def _world_point_at(edge, t):
+    return tuple(edge.start[i] + (edge.end[i] - edge.start[i]) * t
+                 for i in range(3))
+
+
+def _orthographic_view_ray(region_3d, target, clip_end):
+    """Construct a stable parallel viewport ray through ``target``.
+
+    ``region_2d_to_origin_3d`` is intentionally depth-dependent for some
+    orthographic region configurations.  Starting a long way behind the
+    target on the actual view vector keeps every isometric sample on the
+    same parallel ray and matches the render-camera implementation.
+    """
+    direction = (region_3d.view_matrix.inverted().to_3x3()
+                 @ Vector((0.0, 0.0, -1.0))).normalized()
+    origin = Vector(target) - direction * max(clip_end, 1.0)
+    return origin, direction, max(clip_end, 1.0)
+
+
+def _sample_is_visible(context, region, region_3d, target, tolerance):
+    """True when the sample is the first surface along its viewport ray."""
+    target = Vector(target)
+    if region_3d.is_perspective:
+        screen = view3d_utils.location_3d_to_region_2d(region, region_3d, target)
+        if screen is None:
+            return None
+        origin = view3d_utils.region_2d_to_origin_3d(region, region_3d, screen)
+        direction = view3d_utils.region_2d_to_vector_3d(region, region_3d, screen)
+        target_distance = (target - origin).length
+    else:
+        clip_end = getattr(context.space_data, 'clip_end', 1000.0)
+        origin, direction, target_distance = _orthographic_view_ray(
+            region_3d, target, clip_end)
+    hit, location, _normal, _face_index, _object, _matrix = context.scene.ray_cast(
+        context.evaluated_depsgraph_get(), origin, direction,
+        distance=target_distance + tolerance)
+    if not hit:
+        return True
+    # Adjacent faces can be hit at the same depth as their edge.  They are
+    # not occluders; only a surface materially closer to the camera hides it.
+    return (location - origin).length >= target_distance - tolerance
+
+
+def _edge_visibility_runs(context, region, region_3d, edge, sample_count):
+    length = (Vector(edge.end) - Vector(edge.start)).length
+    tolerance = max(1.0e-5, length * 1.0e-5)
+    samples = []
+    for index in range(sample_count):
+        target = _world_point_at(edge, index / (sample_count - 1))
+        result = _sample_is_visible(context, region, region_3d, target, tolerance)
+        samples.append(True if result is None else result)
+    return visibility_runs(samples)
+
+
+def _segment_intersects_region(start, end, region, margin=SCREEN_CULL_MARGIN):
+    """Conservative screen-space rejection for edges outside the viewport."""
+    return not (max(start.x, end.x) < -margin
+                or min(start.x, end.x) > region.width + margin
+                or max(start.y, end.y) < -margin
+                or min(start.y, end.y) > region.height + margin)
+
+
+def visibility_sample_count(max_samples, start, end):
+    """Scale hidden-line samples to the edge's visible pixel length.
+
+    The UI value remains a quality ceiling.  Short projected edges cannot
+    visually benefit from seventeen samples, while long drawing edges retain
+    the higher precision needed for useful hidden-line transitions.
+    """
+    pixel_length = ((end.x - start.x) ** 2 + (end.y - start.y) ** 2) ** 0.5
+    needed = int(pixel_length / VISIBILITY_PIXELS_PER_SAMPLE) + 2
+    return max(VISIBILITY_MIN_SAMPLES, min(max_samples, needed))
+
+
+def _projection_cache_key(context, region, region_3d):
+    selected = tuple(sorted(obj.name for obj in context.selected_objects)) \
+        if context.scene.hb_semantic_edges_selected_only else ()
+    return (context.scene.as_pointer(), region.width, region.height,
+            context.scene.hb_semantic_edge_visibility_mode,
+            context.scene.hb_semantic_edge_sample_count,
+            context.scene.hb_semantic_edges_suppress_aligned_hidden,
+            context.scene.hb_semantic_edges_selected_only, selected,
+            tuple(round(value, 7) for row in region_3d.perspective_matrix
+                  for value in row))
+
+
+def projected_segments(context, region, region_3d):
+    """Project semantic edges and, on demand, classify sampled visibility."""
+    key = _projection_cache_key(context, region, region_3d)
+    if _projection_cache['key'] == key:
+        return _projection_cache['segments']
+
+    depsgraph = context.evaluated_depsgraph_get()
+    mode = context.scene.hb_semantic_edge_visibility_mode
+    navigation_preview = _navigation_is_active(region, region_3d)
+    effective_mode = 'ALL' if navigation_preview else mode
+    segments = []
+    candidates = []
+    for edges in _cached_semantic_edges(context, depsgraph):
+        for edge in edges:
+            edge_start = view3d_utils.location_3d_to_region_2d(
+                region, region_3d, edge.start)
+            edge_end = view3d_utils.location_3d_to_region_2d(
+                region, region_3d, edge.end)
+            if (edge_start is None or edge_end is None
+                    or not _segment_intersects_region(edge_start, edge_end, region)):
+                continue
+            sample_count = visibility_sample_count(
+                context.scene.hb_semantic_edge_sample_count, edge_start, edge_end)
+            candidates.append((edge, sample_count))
+
+    total_samples = sum(sample_count for _edge, sample_count in candidates)
+    _viewport_performance['edges'] = len(candidates)
+    _viewport_performance['samples'] = total_samples
+    _viewport_performance['backend'] = (
+        'Navigation preview' if navigation_preview else
+        ('No visibility pass' if mode == 'ALL' else 'Ray-cast quality pass'))
+    for edge, sample_count in candidates:
+        runs = ((0.0, 1.0, VISIBLE),) if effective_mode == 'ALL' else \
+            _edge_visibility_runs(context, region, region_3d, edge,
+                                  sample_count)
+        for start_t, end_t, visibility in runs:
+            if effective_mode == 'VISIBLE_ONLY' and visibility == HIDDEN:
+                continue
+            start = view3d_utils.location_3d_to_region_2d(
+                region, region_3d, _world_point_at(edge, start_t))
+            end = view3d_utils.location_3d_to_region_2d(
+                region, region_3d, _world_point_at(edge, end_t))
+            if start is not None and end is not None:
+                segments.append(ProjectedEdgeSegment(
+                    edge.uid, (start.x, start.y), (end.x, end.y), visibility))
+    if (effective_mode == 'TECHNICAL'
+            and context.scene.hb_semantic_edges_suppress_aligned_hidden):
+        segments = suppress_aligned_hidden_segments(segments)
+    _projection_cache['key'] = key
+    _projection_cache['segments'] = tuple(segments)
+    return _projection_cache['segments']
+
+
+def _draw_line_batch(shader, vertices, region, color, width):
+    if not vertices:
+        return
+    shader.uniform_float('color', color)
+    shader.uniform_float('viewportSize', (region.width, region.height))
+    shader.uniform_float('lineWidth', width)
+    batch_for_shader(shader, 'LINES', {'pos': vertices}).draw(shader)
+
+
+def _draw_overlay():
+    context = bpy.context
+    if not getattr(context.scene, 'hb_show_semantic_edges', False):
+        return
+    area = context.area
+    if area is None or area.type != 'VIEW_3D':
+        return
+    region = next((item for item in area.regions if item.type == 'WINDOW'), None)
+    region_3d = context.space_data.region_3d
+    if region is None or region_3d is None:
+        return
+
+    segments = projected_segments(context, region, region_3d)
+    if not segments:
+        return
+    shader = gpu.shader.from_builtin('POLYLINE_UNIFORM_COLOR')
+    previous_blend = gpu.state.blend_get()
+    gpu.state.blend_set('ALPHA')
+    try:
+        shader.bind()
+        visible_vertices = [point for segment in segments
+                            if segment.visibility == VISIBLE
+                            for point in (segment.start, segment.end)]
+        color = line_color(context.scene)
+        _draw_line_batch(shader, visible_vertices, region, color,
+                         viewport_line_width(context.scene))
+        hidden_vertices = [point for segment in segments
+                           if segment.visibility == HIDDEN
+                           for dash in dashed_screen_segments(segment.start, segment.end)
+                           for point in dash]
+        _draw_line_batch(shader, hidden_vertices, region, hidden_line_color(color),
+                         hidden_line_width(viewport_line_width(context.scene)))
+    finally:
+        gpu.state.blend_set(previous_blend)
+
+
+def create_semantic_edge_test_objects(context):
+    """Create an inspectable set of mesh cases for the initial overlay."""
+    collection = bpy.data.collections.new(TEST_COLLECTION_NAME)
+    context.scene.collection.children.link(collection)
+
+    def add_mesh(name, vertices, faces, location):
+        mesh = bpy.data.meshes.new(name)
+        mesh.from_pydata(vertices, [], faces)
+        mesh.update()
+        obj = bpy.data.objects.new(name, mesh)
+        obj.location = location
+        collection.objects.link(obj)
+        return obj
+
+    box = add_mesh(
+        'Semantic Test - Box',
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+         (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1)],
+        [(0, 3, 2, 1), (4, 5, 6, 7), (0, 1, 5, 4),
+         (1, 2, 6, 5), (2, 3, 7, 6), (3, 0, 4, 7)],
+        (0, 0, 0))
+    panel = add_mesh(
+        'Semantic Test - Triangulated Panel',
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+        [(0, 1, 2), (0, 2, 3)], (2, 0, 0))
+    fold = add_mesh(
+        'Semantic Test - Sharp Fold',
+        [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)],
+        [(0, 1, 2), (0, 3, 1)], (4, 0, 0))
+    marked = add_mesh(
+        'Semantic Test - Marked Edge',
+        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+        [(0, 1, 2), (0, 2, 3)], (6, 0, 0))
+    attribute = marked.data.attributes.new(semantic_edges.USER_MARKED_ATTRIBUTE,
+                                           'BOOLEAN', 'EDGE')
+    diagonal = next(edge for edge in marked.data.edges
+                    if tuple(sorted(edge.vertices[:])) == (0, 2))
+    attribute.data[diagonal.index].value = True
+
+    bpy.ops.object.select_all(action='DESELECT')
+    for obj in (box, panel, fold, marked):
+        obj.select_set(True)
+    context.view_layer.objects.active = box
+    # The properties exist when the add-on is registered.  Keeping the
+    # factory independent lets the headless semantic-edge tests import it
+    # directly without registering the entire Home Builder add-on.
+    if hasattr(context.scene, 'hb_show_semantic_edges'):
+        context.scene.hb_show_semantic_edges = True
+    if hasattr(context.scene, 'hb_semantic_edges_selected_only'):
+        context.scene.hb_semantic_edges_selected_only = False
+    if hasattr(context.scene, 'hb_semantic_edge_visibility_mode'):
+        context.scene.hb_semantic_edge_visibility_mode = 'TECHNICAL'
+    _redraw_viewports()
+    return (box, panel, fold, marked)
+
+
+class HOME_BUILDER_OT_create_semantic_edge_test_scene(bpy.types.Operator):
+    bl_idname = 'home_builder.create_semantic_edge_test_scene'
+    bl_label = 'Create Semantic Edge Test Objects'
+    bl_description = 'Create meshes for checking semantic edge extraction'
+    bl_options = {'UNDO'}
+
+    def execute(self, context):
+        create_semantic_edge_test_objects(context)
+        self.report({'INFO'}, 'Created semantic-edge test objects')
+        return {'FINISHED'}
+
+
+class HOME_BUILDER_PT_semantic_edges(bpy.types.Panel):
+    """Parent panel for all semantic-edge controls and future consumers."""
+    bl_label = 'Semantic Edges (Experimental)'
+    bl_idname = 'HOME_BUILDER_PT_semantic_edges'
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'Home Builder'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        self.layout.label(text='Opt-in technical-line alternative', icon='INFO')
+
+
+class HOME_BUILDER_PT_semantic_edge_control(bpy.types.Panel):
+    bl_label = 'Edge Control'
+    bl_idname = 'HOME_BUILDER_PT_semantic_edge_control'
+    bl_parent_id = 'HOME_BUILDER_PT_semantic_edges'
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'Home Builder'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(context.scene, 'hb_show_semantic_edges', text='Show Overlay')
+        layout.prop(context.scene, 'hb_semantic_edge_line_color', text='Line Color')
+        layout.prop(context.scene, 'hb_semantic_edge_line_weight', text='Line Weight')
+        layout.prop(context.scene, 'hb_semantic_edge_viewport_weight_multiplier',
+                    text='Viewport Weight')
+        layout.prop(context.scene, 'hb_semantic_edges_selected_only',
+                    text='Selected Objects Only')
+        layout.prop(context.scene, 'hb_semantic_edge_visibility_mode',
+                    text='Visibility')
+        if context.scene.hb_semantic_edge_visibility_mode != 'ALL':
+            layout.prop(context.scene, 'hb_semantic_edge_sample_count',
+                        text='Visibility Samples')
+        if context.scene.hb_semantic_edge_visibility_mode == 'TECHNICAL':
+            layout.prop(context.scene, 'hb_semantic_edges_suppress_aligned_hidden',
+                        text='Suppress Aligned Hidden Lines')
+        layout.separator()
+        layout.label(text='Viewport: {}'.format(_viewport_performance['backend']),
+                     icon='TIME')
+        layout.label(text='{} on-screen edges / {} samples'.format(
+            _viewport_performance['edges'], _viewport_performance['samples']))
+        layout.operator(HOME_BUILDER_OT_create_semantic_edge_test_scene.bl_idname,
+                        icon='MESH_CUBE')
+        layout.label(text='Sampled visibility; exact splitting comes later.', icon='INFO')
+
+
+_classes = (
+    HOME_BUILDER_OT_create_semantic_edge_test_scene,
+    HOME_BUILDER_PT_semantic_edges,
+    HOME_BUILDER_PT_semantic_edge_control,
+)
+
+
+def register():
+    global _draw_handle
+    bpy.types.Scene.hb_show_semantic_edges = BoolProperty(
+        name='Show Semantic Edges', default=False, update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edges_selected_only = BoolProperty(
+        name='Selected Objects Only', default=False, update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edge_line_color = FloatVectorProperty(
+        name='Semantic Edge Line Color', size=4, subtype='COLOR',
+        default=OVERLAY_COLOR, min=0.0, max=1.0, update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edge_line_weight = FloatProperty(
+        name='Semantic Edge Line Weight', default=OVERLAY_LINE_WIDTH,
+        min=0.25, max=8.0, description='Base technical line width in pixels',
+        update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edge_viewport_weight_multiplier = FloatProperty(
+        name='Viewport Line Weight Multiplier', default=1.0,
+        min=0.25, max=4.0,
+        description='Viewport-specific adjustment of the shared line weight',
+        update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edge_render_weight_multiplier = FloatProperty(
+        name='Render Line Weight Multiplier', default=1.25,
+        min=0.25, max=4.0,
+        description='Render-specific adjustment after supersampling',
+        update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edge_visibility_mode = EnumProperty(
+        name='Semantic Edge Visibility',
+        items=(
+            ('ALL', 'All', 'Draw every semantic edge'),
+            ('VISIBLE_ONLY', 'Visible Only', 'Hide occluded edge portions'),
+            ('TECHNICAL', 'Technical', 'Draw occluded portions as dashed lines'),
+        ),
+        default='TECHNICAL', update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edge_sample_count = IntProperty(
+        name='Visibility Samples', default=17, min=3, max=65,
+        description='Ray samples per edge for the initial hidden-line pass',
+        update=_redraw_viewports)
+    bpy.types.Scene.hb_semantic_edges_suppress_aligned_hidden = BoolProperty(
+        name='Suppress Aligned Hidden Lines', default=True,
+        description='Remove hidden lines fully covered by visible collinear lines',
+        update=_redraw_viewports)
+    for cls in _classes:
+        bpy.utils.register_class(cls)
+    _draw_handle = bpy.types.SpaceView3D.draw_handler_add(
+        _draw_overlay, (), 'WINDOW', 'POST_PIXEL')
+    if _depsgraph_update_post not in bpy.app.handlers.depsgraph_update_post:
+        bpy.app.handlers.depsgraph_update_post.append(_depsgraph_update_post)
+
+
+def unregister():
+    global _draw_handle
+    if _draw_handle is not None:
+        bpy.types.SpaceView3D.draw_handler_remove(_draw_handle, 'WINDOW')
+        _draw_handle = None
+    for cls in reversed(_classes):
+        bpy.utils.unregister_class(cls)
+    del bpy.types.Scene.hb_show_semantic_edges
+    del bpy.types.Scene.hb_semantic_edges_selected_only
+    del bpy.types.Scene.hb_semantic_edge_line_color
+    del bpy.types.Scene.hb_semantic_edge_line_weight
+    del bpy.types.Scene.hb_semantic_edge_viewport_weight_multiplier
+    del bpy.types.Scene.hb_semantic_edge_render_weight_multiplier
+    del bpy.types.Scene.hb_semantic_edge_visibility_mode
+    del bpy.types.Scene.hb_semantic_edge_sample_count
+    del bpy.types.Scene.hb_semantic_edges_suppress_aligned_hidden
+    if _depsgraph_update_post in bpy.app.handlers.depsgraph_update_post:
+        bpy.app.handlers.depsgraph_update_post.remove(_depsgraph_update_post)
+    _invalidate_semantic_edge_cache()

--- a/semantic_lines/semantic_edges.py
+++ b/semantic_lines/semantic_edges.py
@@ -1,0 +1,179 @@
+"""Semantic model-edge extraction for Home Builder technical drawings.
+
+This is deliberately the *source* layer only.  It identifies the useful
+edges of an evaluated Blender mesh, keeps a stable Home Builder identity for
+the owning object, and returns neutral records that a later projector,
+visibility solver, viewport overlay, and drawing exporter can share.
+
+Faces are evidence for classification, not line candidates: an edge that is
+only an internal coplanar tessellation diagonal is omitted by default.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import cos, radians
+from typing import Iterable, Optional, Tuple
+from uuid import uuid4
+
+from mathutils import Vector
+
+
+SOURCE_UID_PROPERTY = "HB_SEMANTIC_SOURCE_UID"
+USER_MARKED_ATTRIBUTE = "hb_semantic_edge"
+
+EDGE_BOUNDARY = "BOUNDARY"
+EDGE_SHARP = "SHARP"
+EDGE_USER_MARKED = "USER_MARKED"
+
+Point3 = Tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class SemanticEdge:
+    """One intentional line candidate, expressed in world space.
+
+    ``topology_edge_index`` is useful while a mesh is current, but is not
+    persistent identity.  ``uid`` is stable for the source object and its
+    canonical endpoint topology reference; callers must recreate edge
+    references after a topology change.
+    """
+
+    uid: str
+    source_object_uid: str
+    source_object_name: str
+    topology_edge_index: int
+    topology_vertices: Tuple[int, int]
+    start: Point3
+    end: Point3
+    edge_class: str
+    adjacent_faces: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class EdgeExtractionOptions:
+    """Policy for the first semantic edge extractor.
+
+    A user-marked edge always survives classification.  Boundary edges and
+    edges with an angle at or above ``sharp_angle_degrees`` are candidates.
+    """
+
+    sharp_angle_degrees: float = 30.0
+    include_boundary: bool = True
+    include_sharp: bool = True
+    include_user_marked: bool = True
+    include_loose: bool = True
+
+
+def ensure_source_uid(obj) -> str:
+    """Return Home Builder's persistent UID for an authored object.
+
+    The object, rather than its evaluated copy, owns this identifier.  This
+    is intentionally the only extraction-time write and lets downstream
+    systems retain a meaningful reference as evaluated meshes are rebuilt.
+    """
+    uid = obj.get(SOURCE_UID_PROPERTY)
+    if not uid:
+        uid = str(uuid4())
+        obj[SOURCE_UID_PROPERTY] = uid
+    return str(uid)
+
+
+def extract_semantic_edges(obj, depsgraph=None,
+                           options: Optional[EdgeExtractionOptions] = None
+                           ) -> Tuple[SemanticEdge, ...]:
+    """Extract semantic edges from ``obj``'s evaluated mesh.
+
+    ``obj`` must be a mesh object.  Supplying a depsgraph includes Geometry
+    Nodes and modifiers; omit it for direct mesh tests or authored meshes.
+    This function has no viewport, camera, or rendering dependency.
+    """
+    if obj.type != 'MESH':
+        return ()
+
+    options = options or EdgeExtractionOptions()
+    source_uid = ensure_source_uid(obj)
+    evaluated = obj.evaluated_get(depsgraph) if depsgraph is not None else obj
+    mesh = evaluated.data
+    if mesh is None:
+        return ()
+
+    edge_faces = _edge_face_map(mesh)
+    threshold_cos = cos(radians(options.sharp_angle_degrees))
+    result = []
+    for edge in mesh.edges:
+        edge_index = edge.index
+        faces = edge_faces[edge_index]
+        user_marked = _edge_is_user_marked(mesh, edge_index)
+        edge_class = _classify_edge(mesh, faces, threshold_cos, user_marked,
+                                    options)
+        if edge_class is None:
+            continue
+
+        v0, v1 = sorted(edge.vertices[:])
+        start = _world_point(evaluated.matrix_world, mesh.vertices[v0].co)
+        end = _world_point(evaluated.matrix_world, mesh.vertices[v1].co)
+        uid = f"{source_uid}:{v0}:{v1}"
+        result.append(SemanticEdge(
+            uid=uid,
+            source_object_uid=source_uid,
+            source_object_name=obj.name,
+            topology_edge_index=edge_index,
+            topology_vertices=(v0, v1),
+            start=start,
+            end=end,
+            edge_class=edge_class,
+            adjacent_faces=tuple(faces),
+        ))
+    return tuple(result)
+
+
+def _edge_face_map(mesh) -> Tuple[Tuple[int, ...], ...]:
+    """Map each mesh edge to adjacent polygon indices without BMesh."""
+    by_key = {tuple(sorted(edge.vertices[:])): edge.index for edge in mesh.edges}
+    faces = [[] for _edge in mesh.edges]
+    for polygon in mesh.polygons:
+        vertices = polygon.vertices[:]
+        for index, vertex in enumerate(vertices):
+            key = tuple(sorted((vertex, vertices[(index + 1) % len(vertices)])))
+            edge_index = by_key.get(key)
+            if edge_index is not None:
+                faces[edge_index].append(polygon.index)
+    return tuple(tuple(face_indices) for face_indices in faces)
+
+
+def _classify_edge(mesh, faces: Iterable[int], threshold_cos: float,
+                   user_marked: bool, options: EdgeExtractionOptions) -> Optional[str]:
+    faces = tuple(faces)
+    if user_marked and options.include_user_marked:
+        return EDGE_USER_MARKED
+    if len(faces) == 0:
+        return EDGE_BOUNDARY if options.include_loose else None
+    if len(faces) == 1:
+        return EDGE_BOUNDARY if options.include_boundary else None
+    if not options.include_sharp:
+        return None
+
+    # Manifold meshes normally have two adjacent polygons.  With non-manifold
+    # edges, any materially differing normal makes the edge intentional.
+    normals = [mesh.polygons[index].normal.normalized() for index in faces]
+    first = normals[0]
+    if any(first.dot(normal) < threshold_cos for normal in normals[1:]):
+        return EDGE_SHARP
+    return None
+
+
+def _edge_is_user_marked(mesh, edge_index: int) -> bool:
+    """Read the optional boolean EDGE-domain authoring attribute safely."""
+    attribute = mesh.attributes.get(USER_MARKED_ATTRIBUTE)
+    if attribute is None or attribute.domain != 'EDGE':
+        return False
+    try:
+        return bool(attribute.data[edge_index].value)
+    except (AttributeError, IndexError):
+        return False
+
+
+def _world_point(matrix, coordinate: Vector) -> Point3:
+    point = matrix @ coordinate
+    return (float(point.x), float(point.y), float(point.z))

--- a/semantic_lines/semantic_line_render.py
+++ b/semantic_lines/semantic_line_render.py
@@ -1,0 +1,310 @@
+"""Render-camera consumer for Home Builder semantic edges.
+
+The viewport overlay cannot appear in an F12 render.  This module projects
+the same semantic edges through the render camera, classifies sampled
+visibility, rasterizes a transparent supersampled Pillow image, and inserts
+that image above the existing compositor result.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import bpy
+from bpy.app.handlers import persistent
+from bpy.props import BoolProperty, EnumProperty, IntProperty
+from mathutils import Vector
+from bpy_extras.object_utils import world_to_camera_view
+
+try:
+    from . import semantic_edges, semantic_edge_overlay
+except ImportError:  # Direct Blender-headless test imports.
+    import semantic_edges
+    import semantic_edge_overlay
+
+
+LINE_IMAGE_NAME = 'HB Semantic Line Pass'
+IMAGE_NODE_NAME = 'HB Semantic Lines Image'
+COMPOSITE_NODE_NAME = 'HB Semantic Lines Composite'
+
+
+def _render_candidates(scene):
+    view_layer = bpy.context.view_layer
+    return [obj for obj in scene.objects
+            if obj.type == 'MESH'
+            and not obj.hide_render
+            and obj.visible_get(view_layer=view_layer)]
+
+
+def _world_point_at(edge, t):
+    return tuple(edge.start[i] + (edge.end[i] - edge.start[i]) * t
+                 for i in range(3))
+
+
+def _camera_ray(camera, target):
+    """Return (origin, direction, distance) for a render-camera sample."""
+    target = Vector(target)
+    matrix = camera.matrix_world
+    if camera.data.type == 'ORTHO':
+        local = matrix.inverted() @ target
+        origin = matrix @ Vector((local.x, local.y, 0.0))
+        direction = -(matrix.to_3x3() @ Vector((0.0, 0.0, 1.0))).normalized()
+        distance = (target - origin).dot(direction)
+    else:
+        origin = matrix.translation
+        offset = target - origin
+        distance = offset.length
+        direction = offset.normalized() if distance else Vector((0.0, 0.0, -1.0))
+    return origin, direction, distance
+
+
+def _sample_is_visible(scene, depsgraph, camera, target, tolerance):
+    origin, direction, target_distance = _camera_ray(camera, target)
+    if target_distance <= tolerance:
+        return False
+    hit, location, _normal, _face_index, _object, _matrix = scene.ray_cast(
+        depsgraph, origin, direction, distance=target_distance + tolerance)
+    if not hit:
+        return True
+    return (location - origin).length >= target_distance - tolerance
+
+
+def _visibility_runs(scene, depsgraph, camera, edge, sample_count):
+    length = (Vector(edge.end) - Vector(edge.start)).length
+    tolerance = max(1.0e-5, length * 1.0e-5)
+    samples = [_sample_is_visible(
+        scene, depsgraph, camera,
+        _world_point_at(edge, index / (sample_count - 1)), tolerance)
+        for index in range(sample_count)]
+    return semantic_edge_overlay.visibility_runs(samples)
+
+
+def _image_point(scene, camera, point, width, height):
+    ndc = world_to_camera_view(scene, camera, Vector(point))
+    if ndc.z < 0.0 or not (-0.02 <= ndc.x <= 1.02 and -0.02 <= ndc.y <= 1.02):
+        return None
+    return (ndc.x * width, (1.0 - ndc.y) * height)
+
+
+def camera_projected_segments(scene):
+    """Return projected semantic segments for the active render camera."""
+    camera = scene.camera
+    if camera is None:
+        return ()
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    width = max(1, round(scene.render.resolution_x * scene.render.resolution_percentage / 100))
+    height = max(1, round(scene.render.resolution_y * scene.render.resolution_percentage / 100))
+    mode = scene.hb_semantic_render_mode
+    segments = []
+    for obj in _render_candidates(scene):
+        for edge in semantic_edges.extract_semantic_edges(obj, depsgraph):
+            runs = ((0.0, 1.0, semantic_edge_overlay.VISIBLE),) if mode == 'ALL' else \
+                _visibility_runs(scene, depsgraph, camera, edge,
+                                 scene.hb_semantic_render_sample_count)
+            for start_t, end_t, visibility in runs:
+                if mode == 'VISIBLE_ONLY' and visibility == semantic_edge_overlay.HIDDEN:
+                    continue
+                start = _image_point(scene, camera, _world_point_at(edge, start_t), width, height)
+                end = _image_point(scene, camera, _world_point_at(edge, end_t), width, height)
+                if start is not None and end is not None:
+                    segments.append(semantic_edge_overlay.ProjectedEdgeSegment(
+                        edge.uid, start, end, visibility))
+    if mode == 'TECHNICAL' and scene.hb_semantic_render_suppress_aligned_hidden:
+        segments = semantic_edge_overlay.suppress_aligned_hidden_segments(segments)
+    return tuple(segments)
+
+
+def _rgba(color):
+    return tuple(round(component * 255) for component in color)
+
+
+def render_semantic_line_image(scene):
+    """Build, pack, and return the current scene's transparent line image."""
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError as error:
+        raise RuntimeError('Pillow is required for semantic render lines') from error
+
+    width = max(1, round(scene.render.resolution_x * scene.render.resolution_percentage / 100))
+    height = max(1, round(scene.render.resolution_y * scene.render.resolution_percentage / 100))
+    supersample = scene.hb_semantic_render_supersample
+    image = Image.new('RGBA', (width * supersample, height * supersample), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    segments = camera_projected_segments(scene)
+
+    def scaled(point):
+        return (round(point[0] * supersample), round(point[1] * supersample))
+
+    for segment in segments:
+        if segment.visibility == semantic_edge_overlay.HIDDEN:
+            pieces = semantic_edge_overlay.dashed_screen_segments(segment.start, segment.end)
+            color, line_width = (
+                semantic_edge_overlay.hidden_line_color(
+                    semantic_edge_overlay.line_color(scene)),
+                semantic_edge_overlay.hidden_line_width(
+                    semantic_edge_overlay.render_line_width(scene)))
+        else:
+            pieces = ((segment.start, segment.end),)
+            color, line_width = (semantic_edge_overlay.line_color(scene),
+                                 semantic_edge_overlay.render_line_width(scene))
+        for start, end in pieces:
+            draw.line((scaled(start), scaled(end)), fill=_rgba(color),
+                      width=max(1, round(line_width * supersample)))
+
+    if supersample > 1:
+        image = image.resize((width, height), Image.Resampling.LANCZOS)
+
+    old = bpy.data.images.get(LINE_IMAGE_NAME)
+    if old is not None:
+        bpy.data.images.remove(old)
+    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp:
+        path = temp.name
+    try:
+        image.save(path, 'PNG')
+        result = bpy.data.images.load(path, check_existing=False)
+        result.name = LINE_IMAGE_NAME
+        result.pack()
+        # Blender 5.2 renamed the former display-transform option; line PNGs
+        # are conventional display-referred RGBA imagery.
+        result.colorspace_settings.name = 'sRGB'
+        return result
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+def _compositor_tree(scene):
+    tree = scene.compositing_node_group
+    if tree is None:
+        tree = bpy.data.node_groups.new(f'{scene.name}_Compositor', 'CompositorNodeTree')
+        tree.interface.new_socket(name='Image', in_out='OUTPUT', socket_type='NodeSocketColor')
+        scene.compositing_node_group = tree
+    return tree
+
+
+def composite_semantic_line_image(scene, image):
+    """Insert or update the semantic line layer above the compositor output."""
+    tree = _compositor_tree(scene)
+    nodes, links = tree.nodes, tree.links
+    image_node = nodes.get(IMAGE_NODE_NAME)
+    if image_node is None:
+        image_node = nodes.new('CompositorNodeImage')
+        image_node.name = IMAGE_NODE_NAME
+        image_node.label = 'Semantic Lines'
+        image_node.location = (250, -150)
+    image_node.image = image
+
+    alpha_over = nodes.get(COMPOSITE_NODE_NAME)
+    if alpha_over is None:
+        output = next((node for node in nodes if node.type == 'GROUP_OUTPUT'), None)
+        if output is None:
+            output = nodes.new('NodeGroupOutput')
+            output.location = (600, 200)
+        render_layers = next((node for node in nodes if node.type == 'R_LAYERS'), None)
+        if render_layers is None:
+            render_layers = nodes.new('CompositorNodeRLayers')
+            render_layers.location = (0, 200)
+        alpha_over = nodes.new('CompositorNodeAlphaOver')
+        alpha_over.name = COMPOSITE_NODE_NAME
+        alpha_over.label = 'Semantic Lines Composite'
+        alpha_over.location = (450, 200)
+        output_input = output.inputs[0]
+        existing = output_input.links[0].from_socket if output_input.links else render_layers.outputs['Image']
+        links.new(existing, alpha_over.inputs[0])
+        links.new(image_node.outputs['Image'], alpha_over.inputs[1])
+        links.new(alpha_over.outputs[0], output_input)
+    scene.render.use_compositing = True
+
+
+@persistent
+def prepare_semantic_render_lines(scene, _depsgraph=None):
+    """Refresh the pass immediately before F12 / layout renders begin."""
+    if not getattr(scene, 'hb_semantic_render_enabled', False) or scene.camera is None:
+        return
+    try:
+        composite_semantic_line_image(scene, render_semantic_line_image(scene))
+    except Exception as error:
+        print(f'Home Builder semantic line render skipped: {error}')
+
+
+class HOME_BUILDER_OT_prepare_semantic_line_render(bpy.types.Operator):
+    bl_idname = 'home_builder.prepare_semantic_line_render'
+    bl_label = 'Prepare Semantic Line Pass'
+    bl_description = 'Generate and composite semantic lines for the active render camera'
+
+    def execute(self, context):
+        if context.scene.camera is None:
+            self.report({'ERROR'}, 'The scene needs an active camera')
+            return {'CANCELLED'}
+        try:
+            composite_semantic_line_image(context.scene, render_semantic_line_image(context.scene))
+        except RuntimeError as error:
+            self.report({'ERROR'}, str(error))
+            return {'CANCELLED'}
+        self.report({'INFO'}, 'Semantic line pass prepared for rendering')
+        return {'FINISHED'}
+
+
+class HOME_BUILDER_PT_semantic_line_render(bpy.types.Panel):
+    bl_label = 'Line Rendering'
+    bl_idname = 'HOME_BUILDER_PT_semantic_line_render'
+    bl_parent_id = 'HOME_BUILDER_PT_semantic_edges'
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'Home Builder'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        scene = context.scene
+        layout.prop(scene, 'hb_semantic_render_enabled', text='Render Semantic Lines')
+        layout.prop(scene, 'hb_semantic_render_mode', text='Visibility')
+        if scene.hb_semantic_render_mode != 'ALL':
+            layout.prop(scene, 'hb_semantic_render_sample_count', text='Visibility Samples')
+        if scene.hb_semantic_render_mode == 'TECHNICAL':
+            layout.prop(scene, 'hb_semantic_render_suppress_aligned_hidden',
+                        text='Suppress Aligned Hidden Lines')
+        layout.prop(scene, 'hb_semantic_render_supersample', text='Supersample')
+        layout.prop(scene, 'hb_semantic_edge_render_weight_multiplier',
+                    text='Render Weight')
+        layout.operator(HOME_BUILDER_OT_prepare_semantic_line_render.bl_idname,
+                        icon='RENDER_STILL')
+
+
+_classes = (HOME_BUILDER_OT_prepare_semantic_line_render,
+            HOME_BUILDER_PT_semantic_line_render)
+
+
+def register():
+    bpy.types.Scene.hb_semantic_render_enabled = BoolProperty(
+        name='Render Semantic Lines', default=False)
+    bpy.types.Scene.hb_semantic_render_mode = EnumProperty(
+        name='Semantic Render Visibility',
+        items=(
+            ('ALL', 'All', 'Render every semantic edge'),
+            ('VISIBLE_ONLY', 'Visible Only', 'Omit occluded edge portions'),
+            ('TECHNICAL', 'Technical', 'Render hidden portions as dashed lines'),
+        ), default='TECHNICAL')
+    bpy.types.Scene.hb_semantic_render_sample_count = IntProperty(
+        name='Render Visibility Samples', default=17, min=3, max=65)
+    bpy.types.Scene.hb_semantic_render_suppress_aligned_hidden = BoolProperty(
+        name='Suppress Aligned Hidden Lines', default=True)
+    bpy.types.Scene.hb_semantic_render_supersample = IntProperty(
+        name='Render Supersample', default=2, min=1, max=4)
+    for cls in _classes:
+        bpy.utils.register_class(cls)
+    if prepare_semantic_render_lines not in bpy.app.handlers.render_pre:
+        bpy.app.handlers.render_pre.append(prepare_semantic_render_lines)
+
+
+def unregister():
+    if prepare_semantic_render_lines in bpy.app.handlers.render_pre:
+        bpy.app.handlers.render_pre.remove(prepare_semantic_render_lines)
+    for cls in reversed(_classes):
+        bpy.utils.unregister_class(cls)
+    del bpy.types.Scene.hb_semantic_render_enabled
+    del bpy.types.Scene.hb_semantic_render_mode
+    del bpy.types.Scene.hb_semantic_render_sample_count
+    del bpy.types.Scene.hb_semantic_render_suppress_aligned_hidden
+    del bpy.types.Scene.hb_semantic_render_supersample

--- a/tests/test_semantic_edges.py
+++ b/tests/test_semantic_edges.py
@@ -1,0 +1,245 @@
+"""Run with Blender:
+
+blender --background --factory-startup --python tests/test_semantic_edges.py
+"""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+import bpy
+from mathutils import Matrix
+
+PACKAGE_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PACKAGE_ROOT not in sys.path:
+    sys.path.insert(0, PACKAGE_ROOT)
+
+from semantic_lines import semantic_edges
+from semantic_lines import semantic_edge_overlay
+from semantic_lines import semantic_line_render
+
+
+def make_mesh(name, vertices, faces):
+    mesh = bpy.data.meshes.new(name)
+    mesh.from_pydata(vertices, [], faces)
+    mesh.update()
+    obj = bpy.data.objects.new(name, mesh)
+    bpy.context.scene.collection.objects.link(obj)
+    return obj
+
+
+class SemanticEdgeExtractionTests(unittest.TestCase):
+    def tearDown(self):
+        bpy.ops.object.select_all(action='SELECT')
+        bpy.ops.object.delete(use_global=False)
+        for mesh in list(bpy.data.meshes):
+            if mesh.users == 0:
+                bpy.data.meshes.remove(mesh)
+
+    def test_quad_boundary_edges_are_semantic(self):
+        obj = make_mesh('Quad', [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+                        [(0, 1, 2, 3)])
+        edges = semantic_edges.extract_semantic_edges(obj)
+        self.assertEqual(4, len(edges))
+        self.assertEqual({semantic_edges.EDGE_BOUNDARY},
+                         {edge.edge_class for edge in edges})
+
+    def test_coplanar_triangulation_diagonal_is_excluded(self):
+        obj = make_mesh('TriangulatedQuad',
+                        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+                        [(0, 1, 2), (0, 2, 3)])
+        edges = semantic_edges.extract_semantic_edges(obj)
+        self.assertEqual(4, len(edges))
+        self.assertNotIn((0, 2), {edge.topology_vertices for edge in edges})
+
+    def test_sharp_shared_edge_is_semantic(self):
+        obj = make_mesh('Fold', [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)],
+                        [(0, 1, 2), (0, 3, 1)])
+        edges = semantic_edges.extract_semantic_edges(obj)
+        shared = [edge for edge in edges if edge.topology_vertices == (0, 1)]
+        self.assertEqual(1, len(shared))
+        self.assertEqual(semantic_edges.EDGE_SHARP, shared[0].edge_class)
+
+    def test_user_mark_preserves_coplanar_internal_edge(self):
+        obj = make_mesh('MarkedTriangulation',
+                        [(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+                        [(0, 1, 2), (0, 2, 3)])
+        attr = obj.data.attributes.new(semantic_edges.USER_MARKED_ATTRIBUTE,
+                                       'BOOLEAN', 'EDGE')
+        diagonal = next(edge for edge in obj.data.edges
+                        if tuple(sorted(edge.vertices[:])) == (0, 2))
+        attr.data[diagonal.index].value = True
+        edges = semantic_edges.extract_semantic_edges(obj)
+        marked = [edge for edge in edges if edge.topology_vertices == (0, 2)]
+        self.assertEqual(1, len(marked))
+        self.assertEqual(semantic_edges.EDGE_USER_MARKED, marked[0].edge_class)
+
+    def test_source_uid_and_edge_uid_remain_stable(self):
+        obj = make_mesh('Stable', [(0, 0, 0), (1, 0, 0), (0, 1, 0)],
+                        [(0, 1, 2)])
+        first = semantic_edges.extract_semantic_edges(obj)
+        second = semantic_edges.extract_semantic_edges(obj)
+        self.assertEqual(obj[semantic_edges.SOURCE_UID_PROPERTY],
+                         first[0].source_object_uid)
+        self.assertEqual([edge.uid for edge in first],
+                         [edge.uid for edge in second])
+
+    def test_endpoints_are_returned_in_world_space(self):
+        obj = make_mesh('Translated', [(0, 0, 0), (1, 0, 0), (0, 1, 0)],
+                        [(0, 1, 2)])
+        obj.location = (5, -2, 3)
+        bpy.context.view_layer.update()
+        edge = next(edge for edge in semantic_edges.extract_semantic_edges(obj)
+                    if edge.topology_vertices == (0, 1))
+        self.assertEqual((5.0, -2.0, 3.0), edge.start)
+        self.assertEqual((6.0, -2.0, 3.0), edge.end)
+
+    def test_overlay_test_objects_cover_the_first_edge_cases(self):
+        box, panel, fold, marked = semantic_edge_overlay.create_semantic_edge_test_objects(
+            bpy.context)
+        self.assertEqual(12, len(semantic_edges.extract_semantic_edges(box)))
+        panel_edges = semantic_edges.extract_semantic_edges(panel)
+        self.assertNotIn((0, 2), {edge.topology_vertices for edge in panel_edges})
+        self.assertIn(semantic_edges.EDGE_SHARP,
+                      {edge.edge_class for edge in semantic_edges.extract_semantic_edges(fold)})
+        self.assertIn(semantic_edges.EDGE_USER_MARKED,
+                      {edge.edge_class for edge in semantic_edges.extract_semantic_edges(marked)})
+
+    def test_visibility_runs_split_at_sample_transition_midpoints(self):
+        self.assertEqual(
+            ((0.0, 0.5, semantic_edge_overlay.VISIBLE),
+             (0.5, 1.0, semantic_edge_overlay.HIDDEN)),
+            semantic_edge_overlay.visibility_runs([True, True, False, False]))
+
+    def test_visibility_changes_at_edge_endpoints_do_not_overdraw_corners(self):
+        self.assertEqual(
+            ((0.0, 1.0, semantic_edge_overlay.HIDDEN),),
+            semantic_edge_overlay.visibility_runs([True, False, False, False]))
+        self.assertEqual(
+            ((0.0, 1.0, semantic_edge_overlay.HIDDEN),),
+            semantic_edge_overlay.visibility_runs([False, False, False, True]))
+
+    def test_hidden_dashes_are_generated_in_screen_space(self):
+        dashes = semantic_edge_overlay.dashed_screen_segments(
+            (0.0, 0.0), (20.0, 0.0), dash_length=5.0, gap_length=5.0)
+        self.assertEqual((((0.0, 0.0), (5.0, 0.0)),
+                          ((10.0, 0.0), (15.0, 0.0))), dashes)
+
+    def test_offscreen_segments_are_rejected_before_visibility_sampling(self):
+        region = SimpleNamespace(width=100, height=100)
+        self.assertFalse(semantic_edge_overlay._segment_intersects_region(
+            SimpleNamespace(x=-20.0, y=10.0),
+            SimpleNamespace(x=-5.0, y=40.0), region))
+        self.assertTrue(semantic_edge_overlay._segment_intersects_region(
+            SimpleNamespace(x=-20.0, y=50.0),
+            SimpleNamespace(x=120.0, y=50.0), region))
+
+    def test_visibility_sample_count_adapts_to_projected_length(self):
+        short_start = SimpleNamespace(x=0.0, y=0.0)
+        short_end = SimpleNamespace(x=20.0, y=0.0)
+        long_end = SimpleNamespace(x=480.0, y=0.0)
+        self.assertEqual(3, semantic_edge_overlay.visibility_sample_count(
+            17, short_start, short_end))
+        self.assertEqual(7, semantic_edge_overlay.visibility_sample_count(
+            17, short_start, long_end))
+        self.assertEqual(5, semantic_edge_overlay.visibility_sample_count(
+            5, short_start, long_end))
+
+    def test_fully_aligned_hidden_line_is_suppressed(self):
+        visible = semantic_edge_overlay.ProjectedEdgeSegment(
+            'front', (0.0, 0.0), (20.0, 0.0), semantic_edge_overlay.VISIBLE)
+        hidden = semantic_edge_overlay.ProjectedEdgeSegment(
+            'back', (0.0, 0.0), (20.0, 0.0), semantic_edge_overlay.HIDDEN)
+        self.assertEqual((visible,),
+                         semantic_edge_overlay.suppress_aligned_hidden_segments(
+                             (visible, hidden)))
+
+    def test_offset_or_partially_covered_hidden_line_is_retained(self):
+        visible = semantic_edge_overlay.ProjectedEdgeSegment(
+            'front', (0.0, 0.0), (10.0, 0.0), semantic_edge_overlay.VISIBLE)
+        offset_hidden = semantic_edge_overlay.ProjectedEdgeSegment(
+            'offset', (0.0, 2.0), (20.0, 2.0), semantic_edge_overlay.HIDDEN)
+        partial_hidden = semantic_edge_overlay.ProjectedEdgeSegment(
+            'partial', (0.0, 0.0), (20.0, 0.0), semantic_edge_overlay.HIDDEN)
+        self.assertEqual((visible, offset_hidden, partial_hidden),
+                         semantic_edge_overlay.suppress_aligned_hidden_segments(
+                             (visible, offset_hidden, partial_hidden)))
+
+    def test_render_camera_rays_support_perspective_and_orthographic_views(self):
+        data = bpy.data.cameras.new('Semantic Test Camera')
+        camera = bpy.data.objects.new('Semantic Test Camera', data)
+        bpy.context.scene.collection.objects.link(camera)
+        camera.location = (0.0, 0.0, 0.0)
+
+        origin, direction, distance = semantic_line_render._camera_ray(
+            camera, (0.0, 0.0, -5.0))
+        self.assertEqual((0.0, 0.0, 0.0), tuple(origin))
+        self.assertAlmostEqual(5.0, distance)
+        self.assertAlmostEqual(-1.0, direction.z)
+
+    def test_orthographic_viewport_ray_is_parallel_and_target_aligned(self):
+        region_3d = SimpleNamespace(view_matrix=Matrix.Identity(4))
+        origin, direction, distance = semantic_edge_overlay._orthographic_view_ray(
+            region_3d, (2.0, 3.0, -5.0), 100.0)
+        self.assertEqual((2.0, 3.0, 95.0), tuple(origin))
+        self.assertEqual((0.0, 0.0, -1.0), tuple(direction))
+        self.assertEqual(100.0, distance)
+
+    def test_shared_line_weight_uses_calibrated_viewport_and_render_multipliers(self):
+        scene = SimpleNamespace(
+            hb_semantic_edge_line_weight=2.0,
+            hb_semantic_edge_viewport_weight_multiplier=1.0,
+            hb_semantic_edge_render_weight_multiplier=1.25)
+        self.assertEqual(2.0, semantic_edge_overlay.viewport_line_width(scene))
+        self.assertEqual(2.5, semantic_edge_overlay.render_line_width(scene))
+        self.assertAlmostEqual(1.8, semantic_edge_overlay.hidden_line_width(2.5))
+
+    def test_render_line_pass_creates_packed_image_and_compositor_layer(self):
+        scene = bpy.context.scene
+        old_camera = scene.camera
+        old_resolution = (scene.render.resolution_x, scene.render.resolution_y)
+        old_engine = scene.render.engine
+        data = bpy.data.cameras.new('Semantic Render Camera')
+        camera = bpy.data.objects.new('Semantic Render Camera', data)
+        bpy.context.scene.collection.objects.link(camera)
+        scene.camera = camera
+        scene.render.resolution_x, scene.render.resolution_y = 96, 64
+        make_mesh('Render Cube',
+                  [(-1, -1, -1), (1, -1, -1), (1, 1, -1), (-1, 1, -1),
+                   (-1, -1, 1), (1, -1, 1), (1, 1, 1), (-1, 1, 1)],
+                  [(0, 3, 2, 1), (4, 5, 6, 7), (0, 1, 5, 4),
+                   (1, 2, 6, 5), (2, 3, 7, 6), (3, 0, 4, 7)]).location = (0, 0, -5)
+        semantic_edge_overlay.register()
+        semantic_line_render.register()
+        try:
+            scene.hb_semantic_render_mode = 'TECHNICAL'
+            image = semantic_line_render.render_semantic_line_image(scene)
+            semantic_line_render.composite_semantic_line_image(scene, image)
+            self.assertEqual((96, 64), tuple(image.size))
+            self.assertIsNotNone(image.packed_file)
+            self.assertIn(semantic_line_render.COMPOSITE_NODE_NAME,
+                          scene.compositing_node_group.nodes)
+            scene.render.engine = 'BLENDER_WORKBENCH'
+            scene.hb_semantic_render_enabled = True
+            bpy.ops.render.render()
+            self.assertIsNotNone(bpy.data.images.get('Render Result'))
+        finally:
+            semantic_line_render.unregister()
+            semantic_edge_overlay.unregister()
+            scene.camera = old_camera
+            scene.render.resolution_x, scene.render.resolution_y = old_resolution
+            scene.render.engine = old_engine
+
+        data.type = 'ORTHO'
+        origin, direction, distance = semantic_line_render._camera_ray(
+            camera, (2.0, 3.0, -5.0))
+        self.assertEqual((2.0, 3.0, 0.0), tuple(origin))
+        self.assertAlmostEqual(5.0, distance)
+        self.assertAlmostEqual(-1.0, direction.z)
+
+
+if __name__ == '__main__':
+    # Blender retains its own command-line arguments in sys.argv.  Supplying
+    # an explicit argv keeps unittest from trying to parse --background etc.
+    unittest.main(argv=[sys.argv[0]])


### PR DESCRIPTION
Adds an opt-in alternative to wireframe-based edge display with semantic edge extraction, viewport technical lines, optional render compositing, documentation, and Blender-headless tests. Existing wireframe, Freestyle, and Line Art workflows remain unchanged.