### PR TITLE
Ironing board drawer: shelf on a system hole, front with its reveal

### DIFF
--- a/product_libraries/closets/types_closets.py
+++ b/product_libraries/closets/types_closets.py
@@ -3343,8 +3343,18 @@ class ClosetStarter(GeoNodeCage):
         pg.set_input('Thickness', plat_t)
         # The shelf that caps the compartment. Its underside sits the
         # compartment height above the plate, so raising the plate
-        # thickness raises the shelf with it.
-        cap_z = min(open_h + plat_t, max(interior_h - st, 0.0))
+        # thickness raises the shelf with it - and that is exactly what
+        # walked it off the lattice: the plate is 19.05mm and the holes
+        # run 12.95 + n*32mm up from the interior bottom, so open_h +
+        # plat_t landed between two of them. The shelf rests on pins, so
+        # its underside has to BE a hole. Snap up rather than down, so
+        # the compartment never comes out shorter than it was asked for
+        # and the board still fits.
+        want = open_h + plat_t
+        cap_z = const.snap_system_hole(want)
+        if cap_z + 1e-9 < want:
+            cap_z += const.SYSTEM_PITCH
+        cap_z = min(cap_z, max(interior_h - st, 0.0))
         shelf = self._acc_part(cage, 'Accessory Shelf',
                                PART_ROLE_ACCESSORY_PART, kids)
         shelf.location = (0.0, 0.0, cap_z)
@@ -3359,7 +3369,12 @@ class ClosetStarter(GeoNodeCage):
         found = kids.get(PART_ROLE_DRAWER_FRONT) or ()
         front = found[0] if found else None
         if front is not None:
-            f_h = cap_z + bo
+            # cap_z is the shelf's UNDERSIDE, so a front stopping there
+            # laps nothing and leaves the whole shelf edge showing. It
+            # laps up onto the shelf by the top overlay, the way the
+            # front above laps down onto it, and the two then split the
+            # shelf with VERTICAL_GAP between them.
+            f_h = cap_z + bo + to
             front.location = (-lo, front_y, -bo)
             fg = GeoNodeCutpart(front)
             fg.set_input('Length', width + lo + ro)


### PR DESCRIPTION
The shelf capping the compartment rests on pins, so its underside has to BE a system hole - 12.95 + n*32mm up from the interior bottom. It sat at open_h + plat_t = 127 + 19.05 = 146.05mm, which is (146.05-12.95)/32 = 4.16 lattice steps: between two holes. The plate is what put it there, exactly as in 4.3. cap_z now snaps to a hole, upward, so the compartment never comes back shorter than asked for and the board still fits.

The front stopped at cap_z, the shelf's UNDERSIDE, so it lapped nothing and left the whole shelf edge showing - the function's own comment already said it should lap "by the standard overlay". It now laps up onto the shelf by the top overlay, the way the front above laps down onto it, and the two split the shelf with VERTICAL_GAP between them.

Measured on a built drawer, 24 x 14 x 84 opening:

    cap_z 172.950mm -> (172.950-12.95)/32 = 5.000000 exactly, on a hole
    clear above the plate 153.900mm (6.059"), board needs 127.0mm
    front laps the shelf by 0.3125", the overlay
    reveal to a front above 0.1250", exactly VERTICAL_GAP